### PR TITLE
Updating rename project script as circleCI is no recommended

### DIFF
--- a/rename-project.bash
+++ b/rename-project.bash
@@ -72,9 +72,6 @@ sed -i -z -E \
 RANDOM_HOUR=$((RANDOM % (9 - 3 + 1) + 3))
 RANDOM_MINUTE=$(($RANDOM%60))
 RANDOM_MINUTE2=$(($RANDOM%60))
-sed -i -z -E \
-  -e "s/SLACK_RELEASES_CHANNEL/$SLACK_RELEASES_CHANNEL/" \
-  .circleci/config.yml
 
 # lastly remove ourselves
 rm rename-project.bash


### PR DESCRIPTION
CircleCI is not being used now and the rename project script references a file that does not exist