### PR TITLE
Add paths and types from CAS2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "passport": "^0.7.0",
         "passport-oauth2": "^1.8.0",
         "redis": "^4.7.0",
+        "static-path": "^0.0.4",
         "superagent": "^10.1.1"
       },
       "devDependencies": {
@@ -12114,6 +12115,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/static-path": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/static-path/-/static-path-0.0.4.tgz",
+      "integrity": "sha512-RAe93sPAKMDDuXuyU4UKJ+Sm84XJXk3JH21jlPu3bhs30o9Z3abRF6AE8qZCjCWPlJQrHIy4NfxO5CeYOThLFg==",
+      "license": "ISC"
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "passport": "^0.7.0",
     "passport-oauth2": "^1.8.0",
     "redis": "^4.7.0",
+    "static-path": "^0.0.4",
     "superagent": "^10.1.1"
   },
   "devDependencies": {

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -5,6 +5,7 @@ export declare module 'express-session' {
   interface SessionData {
     returnTo: string
     nowInMinutes: number
+    previousPage: string
   }
 }
 
@@ -19,11 +20,23 @@ export declare global {
     interface Request {
       verified?: boolean
       id: string
+      flash(type: string, message: string | ErrorMessages | Array<ErrorSummary> | Record<string, unknown>): number
       logout(done: (err: unknown) => void): void
     }
 
     interface Locals {
       user: HmppsUser
     }
+  }
+}
+
+declare module 'express' {
+  interface TypedRequest<T extends Query, U = Body> extends Express.Request {
+    body: U
+    params: T
+  }
+
+  interface TypedRequestHandler<T, U = Response> extends Express.RequestHandler {
+    (req: T, res: U, next: () => void): void
   }
 }

--- a/server/@types/nunjucks/index.d.ts
+++ b/server/@types/nunjucks/index.d.ts
@@ -1,0 +1,7 @@
+export default {}
+
+declare module 'nunjucks' {
+  export interface ConfigureOptions {
+    dev?: boolean | undefined
+  }
+}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,0 +1,204 @@
+import { OASysRiskOfSeriousHarm } from '../shared/models/OASysRiskOfSeriousHarm'
+import { OASysRiskToSelf } from '../shared/models/OASysRiskToSelf'
+import { RoshRisksEnvelope } from '../shared/models/RoshRisksEnvelope'
+
+export type JourneyType = 'applications'
+
+export type UiTask = {
+  id: string
+  title: string
+  pages: Record<string, unknown>
+}
+export type FormSection = {
+  title: string
+  name: string
+  tasks: Array<UiTask>
+}
+
+export type FormSections = Array<FormSection>
+
+export type TaskNames = 'funding-information' | 'confirm-eligibility' | 'equality-and-diversity-monitoring'
+
+export type FormPages = { [key in TaskNames]: Record<string, unknown> }
+
+export type TaskStatus = 'not_started' | 'in_progress' | 'complete' | 'cannot_start'
+export type TaskWithStatus = UiTask & { status: TaskStatus }
+
+export type TaskListErrors<K extends TaskListPage> = Partial<Record<keyof K['body'], unknown>>
+interface TaskListPage {
+  body: Record<string, unknown>
+}
+
+export type YesOrNo = 'yes' | 'no'
+
+export type YesOrNoOrPreferNotToSay = 'yes' | 'no' | 'preferNotToSay'
+
+export type YesNoOrDontKnow = YesOrNo | 'dontKnow'
+
+export type YesOrNoWithDetail<T extends string> = {
+  [K in T]: YesOrNo
+} & {
+  [K in `${T}Detail`]: string
+}
+
+export type FormArtifact = Cas2Application
+
+export type DataServices = Partial<{
+  personService: {
+    findByPrisonNumber: (token: string, prisonNumber: string) => Promise<Person>
+    getOasysRiskToSelf: (token: string, crn: string) => Promise<OASysRiskToSelf>
+    getOasysRosh: (token: string, crn: string) => Promise<OASysRiskOfSeriousHarm>
+    getRoshRisks: (token: string, crn: string) => Promise<RoshRisksEnvelope>
+  }
+  applicationService: {
+    findApplication: (token: string, id: string) => Promise<Cas2Application>
+  }
+  submittedApplicationService: {
+    findApplication: (token: string, id: string) => Promise<Cas2SubmittedApplication>
+  }
+  userService: {
+    getUserById: (token: string, id: string) => Promise<User>
+  }
+}>
+
+export interface ErrorsAndUserInput {
+  errorTitle?: string
+  errors: ErrorMessages
+  errorSummary: Array<string>
+  userInput: Record<string, unknown>
+}
+
+export interface ErrorMessage {
+  text: string
+  attributes: {
+    [K: string]: boolean
+  }
+}
+export interface ErrorMessages {
+  [K: string]: ErrorMessage
+}
+
+export interface ErrorSummary {
+  text?: string
+  html?: string
+  href?: string
+}
+
+export type UserDetails = {
+  id: string
+  name: string
+  displayName: string
+  roles: Array<UserRole>
+}
+
+export type OasysImportArrays = ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
+
+export type RiskLevel = 'Low' | 'Medium' | 'High' | 'Very High'
+
+export type TierNumber = '1' | '2' | '3' | '4'
+export type TierLetter = 'A' | 'B' | 'C' | 'D'
+export type RiskTierLevel = `${TierLetter}${TierNumber}`
+
+// A utility type that allows us to define an object with a date attribute split into
+// date, month, year (and optionally, time) attributes. Designed for use with the GOV.UK
+// date input
+export type ObjectWithDateParts<K extends string | number> = { [P in `${K}-${'year' | 'month' | 'day'}`]: string } & {
+  [P in `${K}-time`]?: string
+} & {
+  [P in K]?: string
+}
+
+export type TableRow = Array<TableCell>
+
+export type Radio = {
+  attributes?: { [K: string]: string }
+  text: string
+  value: string
+  checked?: boolean
+  hint?: { text: string }
+  conditional?: {
+    html?: string
+  }
+}
+
+export type RadioItem = Radio | Divider
+
+export type Divider = { divider: string }
+
+export interface GroupedApplications {
+  inProgress: Array<ApplicationSummary>
+  submitted: Array<ApplicationSummary>
+}
+
+export type CheckboxItem =
+  | {
+      text: string
+      value: string
+      checked?: boolean
+    }
+  | Divider
+
+export interface SummaryListItem {
+  key: TextItem | HtmlItem
+  value: TextItem | HtmlItem
+  actions?: { items: Array<SummaryListActionItem> }
+}
+
+export type Task = {
+  id: string
+  title: string
+  actionText: string
+  pages: Record<string, unknown>
+}
+
+export interface TextItem {
+  text: string
+}
+
+export interface HtmlItem {
+  html: string
+}
+
+export type QuestionAndAnswer = {
+  question: string
+  answer: string
+}
+
+export type ApplicationDocument = {
+  sections: Array<{
+    title: string
+    tasks: Array<{ title: string; questionsAndAnswers: Array<QuestionAndAnswer> }>
+  }>
+}
+
+export type UiTimelineEvent = {
+  label: { text: string }
+  byline: { text: string }
+  datetime: { timestamp: string; date: string }
+  description: { text: string }
+}
+
+export type PersonStatus = 'InCustody' | 'InCommunity'
+
+export type SelectItem = { value: string; text: string; selected?: boolean }
+
+export type ServiceSection = {
+  id: string
+  title: string
+  description: string
+  shortTitle: string
+  href: string
+}
+
+export type SideNavItem = {
+  text: string
+  href: string
+}
+
+export type PaginatedResponse<T> = {
+  data: Array<T>
+  pageNumber: string
+  totalPages: string
+  totalResults: string
+  pageSize: string
+}

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -1,0 +1,56 @@
+import { path } from 'static-path'
+
+const peoplePath = path('/cas2/people')
+const personPath = peoplePath.path(':crn')
+const oasysPath = personPath.path('oasys')
+const applicationsPath = path('/cas2/applications')
+const abandonPath = applicationsPath.path(':id').path('abandon')
+const singleApplicationPath = applicationsPath.path(':id')
+const singleAssessmentPath = path('/cas2/assessments/:id')
+const submissionsPath = path('/cas2/submissions')
+const singleSubmissionPath = submissionsPath.path(':id')
+const referenceDataPath = path('/cas2/reference-data')
+const reportsPath = path('/cas2/reports')
+const singleReportPath = reportsPath.path(':name')
+
+export default {
+  people: {
+    oasys: {
+      sections: oasysPath.path('sections'),
+      riskToSelf: oasysPath.path('risk-to-self'),
+      rosh: oasysPath.path('rosh'),
+    },
+    search: peoplePath.path('search'),
+    risks: {
+      show: personPath.path('risks'),
+    },
+  },
+  submissions: {
+    index: submissionsPath,
+    create: submissionsPath,
+    show: singleSubmissionPath,
+  },
+  applications: {
+    new: applicationsPath,
+    index: applicationsPath,
+    abandon: abandonPath,
+    show: singleApplicationPath,
+    update: singleApplicationPath,
+  },
+  assessments: {
+    show: singleAssessmentPath,
+    update: singleAssessmentPath,
+    applicationNotes: {
+      create: singleAssessmentPath.path('notes'),
+    },
+  },
+  referenceData: {
+    applicationStatuses: referenceDataPath.path('application-status'),
+  },
+  assessmentStatusUpdates: {
+    create: singleAssessmentPath.path('status-updates'),
+  },
+  reports: {
+    show: singleReportPath,
+  },
+}

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -1,0 +1,41 @@
+import { path } from 'static-path'
+
+const applicationsPath = path('/applications')
+const singleApplicationPath = applicationsPath.path(':id')
+const pagesPath = singleApplicationPath.path('tasks/:task/pages/:page')
+const peoplePath = applicationsPath.path('people')
+
+const appendToListPath = pagesPath.path('/appendToList')
+
+const removeFromListPath = pagesPath.path(':index/removeFromList')
+
+const prisonDashboardPath = applicationsPath.path('prison')
+
+const paths = {
+  applications: {
+    create: applicationsPath.path('create'),
+    index: applicationsPath,
+    prison: prisonDashboardPath,
+    new: applicationsPath.path('new'),
+    beforeYouStart: applicationsPath.path('before-you-start'),
+    people: {
+      find: peoplePath.path('find'),
+    },
+    show: singleApplicationPath,
+    overview: singleApplicationPath.path('overview'),
+    submission: singleApplicationPath.path('submission'),
+    pages: {
+      show: pagesPath,
+      update: pagesPath,
+    },
+    update: singleApplicationPath,
+    appendToList: appendToListPath,
+    removeFromList: removeFromListPath,
+    ineligible: singleApplicationPath.path('not-eligible'),
+    consentRefused: singleApplicationPath.path('no-consent-given'),
+    addNote: singleApplicationPath.path('add-note'),
+    cancel: singleApplicationPath.path('cancel'),
+  },
+}
+
+export default paths

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -1,0 +1,27 @@
+import { path } from 'static-path'
+
+const assessApplicationsPath = path('/assess/applications')
+const singleApplicationPath = assessApplicationsPath.path(':id')
+const updateStatusPath = singleApplicationPath.path('update-status')
+const statusUpdateDetailsPath = updateStatusPath.path('further-information/:statusName')
+
+export default {
+  submittedApplications: {
+    index: assessApplicationsPath,
+    show: singleApplicationPath,
+    overview: singleApplicationPath.path('overview'),
+    addNote: singleApplicationPath.path('add-note'),
+  },
+  statusUpdate: {
+    new: updateStatusPath,
+    create: updateStatusPath,
+  },
+  statusUpdateDetails: {
+    new: statusUpdateDetailsPath,
+    create: statusUpdateDetailsPath,
+  },
+  assessmentDetails: {
+    show: singleApplicationPath.path('assessment-details'),
+    update: singleApplicationPath.path('assessment-details/update'),
+  },
+}

--- a/server/paths/report.ts
+++ b/server/paths/report.ts
@@ -1,0 +1,11 @@
+import { path } from 'static-path'
+
+const reportPath = path('/reports')
+const singleReportPath = reportPath.path(':name')
+
+export default {
+  report: {
+    new: reportPath,
+    create: singleReportPath,
+  },
+}

--- a/server/paths/static.ts
+++ b/server/paths/static.ts
@@ -1,0 +1,17 @@
+import { path } from 'static-path'
+
+const cookiesPolicyPath = path('/cookies')
+const maintenancePath = path('/maintenance')
+const privacyNoticePath = path('/privacy-notice')
+const accessibilityStatementPath = path('/accessibility-statement')
+
+const paths = {
+  static: {
+    cookiesPolicy: cookiesPolicyPath,
+    maintenancePage: maintenancePath,
+    privacyNotice: privacyNoticePath,
+    accessibilityStatement: accessibilityStatementPath,
+  },
+}
+
+export default paths


### PR DESCRIPTION
[JIRA](https://dsdmoj.atlassian.net/browse/CBA-10?atlOrigin=eyJpIjoiYTkyZjIyYTMxZDc5NDQxMjk2YmQwYmFiMjMwZjc0MDMiLCJwIjoiaiJ9)

As we’re building on top of the original CAS2’s functionality for CAS2 bail, we are copying over functionality from the CAS2 repo.

This commit adds the CAS2 paths and the rest of the types.