### PR TITLE
Fixed a missing change to Bail wording in an integration test

### DIFF
--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -2,7 +2,7 @@ import Page, { PageElement } from './page'
 
 export default class IndexPage extends Page {
   constructor() {
-    super('CAS-2: Short-Term Accommodation')
+    super('CAS-2: Bail Accommodation')
   }
 
   headerUserName = (): PageElement => cy.get('[data-qa=header-user-name]')


### PR DESCRIPTION
Missed the note and the failed test from https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui/pull/15, so this fixes that