### PR TITLE
Ensure app deploys to dev even with integration tests skipped

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -60,8 +60,9 @@ jobs:
     name: Build docker image from hmpps-github-actions
     if: github.ref == 'refs/heads/main'
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v1 # WORKFLOW_VERSION
-    needs: 
-      - node_integration_tests
+    needs:
+    # ensure app gets deployed to dev regardless of integration tests being skipped
+    # - node_integration_tests
       - node_unit_tests
     with:
       docker_registry: 'ghcr.io'


### PR DESCRIPTION
In a recent change, we temporarily skipped the integration test step until the full test suite is in place. As subsequent jobs relied on the tests, this stopped Github Actions deploying to dev. This change ensures we deploy regardless of the integration test step.

# Context

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
