### PR TITLE
Customise dashboard tiles based on user roles

### DIFF
--- a/server/controllers/dashboardController.ts
+++ b/server/controllers/dashboardController.ts
@@ -4,7 +4,7 @@ import { sectionsForUser } from '../utils/userUtils'
 export default class DashboardController {
   index(): RequestHandler {
     return (_req: Request, res: Response) => {
-      const sections = sectionsForUser()
+      const sections = sectionsForUser(res.locals.user.userRoles)
 
       res.render('dashboard/index', {
         pageHeading: 'CAS-2: Bail Accommodation',

--- a/server/utils/userUtils.test.ts
+++ b/server/utils/userUtils.test.ts
@@ -2,9 +2,28 @@ import { sectionsForUser, sections } from './userUtils'
 
 describe('userUtils', () => {
   describe('sectionsForUser', () => {
+    it('should return an empty array for a user with no roles', () => {
+      expect(sectionsForUser([])).toEqual([])
+    })
+
     it('should return correct sections for a POM', () => {
       const expected = [sections.applications, sections.newApplication]
-      expect(sectionsForUser()).toEqual(expected)
+      expect(sectionsForUser(['POM'])).toEqual(expected)
+    })
+
+    it('should return the prison dashboard for a Licence CA', () => {
+      const expected = [sections.applications, sections.newApplication]
+      expect(sectionsForUser(['LICENCE_CA'])).toEqual(expected)
+    })
+
+    it('should return correct sections for an admin', () => {
+      const expected = [sections.submittedApplications]
+      expect(sectionsForUser(['CAS2_ADMIN'])).toEqual(expected)
+    })
+
+    it('should return correct sections for a management information user', () => {
+      const expected = [sections.managementInformationReports]
+      expect(sectionsForUser(['CAS2_MI'])).toEqual(expected)
     })
   })
 })

--- a/server/utils/userUtils.ts
+++ b/server/utils/userUtils.ts
@@ -39,11 +39,19 @@ export const hasRole = (userRoles: Array<string>, role: string): boolean => {
   return userRoles.includes(role)
 }
 
-export const sectionsForUser = (): Array<ServiceSection> => {
+export const sectionsForUser = (userRoles: Array<string>): Array<ServiceSection> => {
   const items = []
 
-  items.push(sections.applications)
-  items.push(sections.newApplication)
+  if (hasRole(userRoles, 'POM') || hasRole(userRoles, 'LICENCE_CA')) {
+    items.push(sections.applications)
+    items.push(sections.newApplication)
+  }
+  if (hasRole(userRoles, 'CAS2_ADMIN')) {
+    items.push(sections.submittedApplications)
+  }
+  if (hasRole(userRoles, 'CAS2_MI')) {
+    items.push(sections.managementInformationReports)
+  }
 
   return Array.from(new Set(items))
 }


### PR DESCRIPTION
# Changes in this PR

Copies over HDC code to conditionally render dashboard tiles based on user roles.

NB This will render no tiles for assessors, as within HDC they have not been given tiles on the index page dashboard - instead they are given links to specific applications or their own assessor dashboard.

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
