### PR TITLE
Remove HDC guidance from confirm eligibility page

### DIFF
--- a/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
+++ b/server/views/applications/pages/confirm-eligibility/confirm-eligibility.njk
@@ -35,15 +35,6 @@
       <li>
         be able to live independently. This means they are able to cook, clean and shop for themselves, and manage their own personal hygiene and medication
       </li>
-      <li>
-        if a Home Detention Curfew (HDC) applicant, not be currently in prison having been recalled for failing to comply with HDC licence conditions
-      </li>
-      <li>
-        if a HDC applicant, not have an outstanding charge related to an offence committed during their current sentence. This would make them ineligible for HDC and CAS-2
-      </li>
-      <li>
-        if a HDC applicant, have a conditional release date (CRD) that is more than 10 days from the application submitted date
-      </li>
     </ul>
   </div>
 


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-45

# Changes in this PR

## Screenshots of UI changes

### Before

![Screenshot 2024-12-10 at 11 03 05](https://github.com/user-attachments/assets/918e309a-c8ca-4502-976f-13569c96b3b4)

### After

![Screenshot 2024-12-10 at 10 45 58](https://github.com/user-attachments/assets/709c54c4-be2d-4db6-8d68-988fc8a48cef)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
