### PR TITLE
fix/udate slack security alerts slack channel to #cas-events

### DIFF
--- a/.github/workflows/security_npm_dependency.yml
+++ b/.github/workflows/security_npm_dependency.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security npm dependency check
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_npm_dependency.yml@v1.0 # WORKFLOW_VERSION
     with:
-      channel_id: C05J915DX0Q
+      channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security trivy dependency check
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_trivy.yml@v1.0 # WORKFLOW_VERSION
     with:
-      channel_id: C05J915DX0Q
+      channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security veracode pipeline scan
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_pipeline_scan.yml@v1.0 # WORKFLOW_VERSION
     with:
-      channel_id: C05J915DX0Q
+      channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security veracode policy scan
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_policy_scan.yml@v1.0 # WORKFLOW_VERSION
     with:
-      channel_id: C05J915DX0Q
+      channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit


### PR DESCRIPTION
Fix for HEAT-473 - incorrect slack channel in Security scan notifications.

