### PR TITLE
Strip out guidance text from start application page

### DIFF
--- a/server/views/applications/before-you-start.njk
+++ b/server/views/applications/before-you-start.njk
@@ -9,13 +9,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1>Apply for Short-Term Accommodation (CAS-2)</h1>
-      <p>Use this service to apply for accommodation and support on behalf of someone on Home Detention Curfew (HDC) licence.</p>
-
-      <p>You can save your progress and return to your application at any time.</p>
-
-      <div class="govuk-inset-text">
-        <p>Prison bail applications must be submitted using the paper form.</p>
-      </div>
 
       {{ govukButton({
           text: "Start now",
@@ -23,36 +16,6 @@
           preventDoubleClick: true,
           href: paths.applications.new()
       }) }}
-
-      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-    </div>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2>Before you start</h2>
-
-      <h3>You need:</h3>
-
-      <ul>
-        <li>consent from the applicant</li>
-        <li>the applicant's prison number (from NOMIS)</li>
-        <li>a Layer 3 OASys for the applicant, which has been updated in the last 6 months</li>
-      </ul>
-
-      <details class="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            What to do if OASys is not up to date
-          </span>
-        </summary>
-        <div class="govuk-details__text govuk-body-text">
-          <p>Information in the application should be up to date and consistent with OASys.</p>
-
-          <p>If you can update OASys, do this before you start so risk information can be imported to save you time.</p>
-
-          <p>If the applicant does not have an OASys or you cannot update it, you can complete the sections manually.</p>
-        </div>
-      </details>
 
     </div>
   </div>


### PR DESCRIPTION
We aren’t sure what we want on this page, but we think we will want something, so for now we’re keeping the page but removing the content.

# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-93.

# Changes in this PR

## Screenshots of UI changes

### Before

![Screenshot 2025-01-09 at 14 55 14](https://github.com/user-attachments/assets/3d463d7c-11cb-4877-aba8-43e28d7f4951)

### After

![Screenshot 2025-01-09 at 14 55 42](https://github.com/user-attachments/assets/16866c91-0eb0-4708-938b-2d1d17b36b99)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
