### PR TITLE
CBA-103: move Liaison and Diversion page to top of health needs task

### DIFF
--- a/e2e-tests/steps/risksAndNeedsSection.ts
+++ b/e2e-tests/steps/risksAndNeedsSection.ts
@@ -6,13 +6,13 @@ export const completeHealthNeedsTask = async (page: Page, name: string) => {
   await taskListPage.clickTask('Add health needs')
 
   await reviewGuidancePage(page, name)
+  await completeLiaisonAndDiversionPage(page, name)
   await completeSubstanceMisusePage(page, name)
   await completePhysicalHealthPage(page, name)
   await completeMentalHealthPage(page, name)
   await completeCommunicationAndLanguagePage(page, name)
   await completeLearningDifficultiesPage(page, name)
   await completeBrainInjuryPage(page, name)
-  await completeLiaisonAndDiversionPage(page, name)
   await completeOtherHealthPage(page, name)
 }
 

--- a/server/form-pages/apply/risks-and-needs/health-needs/brainInjury.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/brainInjury.test.ts
@@ -53,7 +53,7 @@ describe('BrainInjury', () => {
     })
   })
 
-  itShouldHaveNextValue(new BrainInjury({}, application), 'liaison-and-diversion')
+  itShouldHaveNextValue(new BrainInjury({}, application), 'other-health')
   itShouldHavePreviousValue(new BrainInjury({}, application), 'learning-difficulties')
 
   describe('errors', () => {

--- a/server/form-pages/apply/risks-and-needs/health-needs/brainInjury.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/brainInjury.ts
@@ -52,7 +52,7 @@ export default class BrainInjury implements TaskListPage {
   }
 
   next() {
-    return 'liaison-and-diversion'
+    return 'other-health'
   }
 
   errors() {

--- a/server/form-pages/apply/risks-and-needs/health-needs/guidance.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/guidance.test.ts
@@ -13,7 +13,7 @@ describe('Guidance', () => {
     })
   })
 
-  itShouldHaveNextValue(new Guidance({}, application), 'substance-misuse')
+  itShouldHaveNextValue(new Guidance({}, application), 'liaison-and-diversion')
   itShouldHavePreviousValue(new Guidance({}, application), 'taskList')
 
   describe('errors', () => {

--- a/server/form-pages/apply/risks-and-needs/health-needs/guidance.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/guidance.ts
@@ -29,7 +29,7 @@ export default class Guidance implements TaskListPage {
   }
 
   next() {
-    return 'substance-misuse'
+    return 'liaison-and-diversion'
   }
 
   errors() {

--- a/server/form-pages/apply/risks-and-needs/health-needs/liaisonAndDiversion.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/liaisonAndDiversion.test.ts
@@ -23,8 +23,8 @@ describe('LiaisonAndDiversion', () => {
     })
   })
 
-  itShouldHaveNextValue(new LiaisonAndDiversion({}, application), 'other-health')
-  itShouldHavePreviousValue(new LiaisonAndDiversion({}, application), 'brain-injury')
+  itShouldHaveNextValue(new LiaisonAndDiversion({}, application), 'substance-misuse')
+  itShouldHavePreviousValue(new LiaisonAndDiversion({}, application), 'taskList')
 
   describe('errors', () => {
     describe('when top-level questions are unanswered', () => {

--- a/server/form-pages/apply/risks-and-needs/health-needs/liaisonAndDiversion.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/liaisonAndDiversion.ts
@@ -32,11 +32,11 @@ export default class LiaisonAndDiversion implements TaskListPage {
   }
 
   previous() {
-    return 'brain-injury'
+    return 'taskList'
   }
 
   next() {
-    return 'other-health'
+    return 'substance-misuse'
   }
 
   errors() {

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.test.ts
@@ -45,7 +45,7 @@ describe('SubstanceMisuse', () => {
   })
 
   itShouldHaveNextValue(new SubstanceMisuse({}, application), 'physical-health')
-  itShouldHavePreviousValue(new SubstanceMisuse({}, application), 'taskList')
+  itShouldHavePreviousValue(new SubstanceMisuse({}, application), 'liaison-and-diversion')
 
   describe('errors', () => {
     describe('when top-level questions are unanswered', () => {

--- a/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/substanceMisuse.ts
@@ -52,7 +52,7 @@ export default class SubstanceMisuse implements TaskListPage {
   }
 
   previous() {
-    return 'taskList'
+    return 'liaison-and-diversion'
   }
 
   next() {

--- a/server/views/applications/pages/health-needs/_health-needs-screen.njk
+++ b/server/views/applications/pages/health-needs/_health-needs-screen.njk
@@ -23,6 +23,10 @@
       {{ mojSideNavigation({
           label: 'Health needs navigation',
           items: [{
+            text: 'Liaison & Diversion',
+            href: paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'liaison-and-diversion' }),
+            active: (pageName === 'liaison-and-diversion')
+          }, {
             text: 'Substance misuse',
             href: paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'substance-misuse' }),
             active: (pageName === 'substance-misuse')
@@ -46,10 +50,6 @@
             text: 'Brain injury',
             href: paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'brain-injury' }),
             active: (pageName === 'brain-injury')
-          }, {
-            text: 'Liaison & Diversion',
-            href: paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'liaison-and-diversion' }),
-            active: (pageName === 'liaison-and-diversion')
           }, {
             text: 'Other health',
             href: paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'other-health' }),

--- a/server/views/applications/pages/health-needs/guidance.njk
+++ b/server/views/applications/pages/health-needs/guidance.njk
@@ -79,7 +79,7 @@
     href: paths.applications.pages.show({
           id: page.application.id,
           task: 'health-needs',
-          page: 'substance-misuse'
+          page: 'liaison-and-diversion'
         })
     }) }}
     </div>


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-103

# Changes in this PR

Moves L&D page to the top of the health needs task, in line with the paper form.

## Screenshots of UI changes

### Before

![Screenshot 2025-01-14 at 12 03 53](https://github.com/user-attachments/assets/879455d6-7e1f-4e2e-98f9-7374d0402f66)

### After

![Screenshot 2025-01-14 at 12 02 34](https://github.com/user-attachments/assets/e735035a-df46-41a5-99a5-247778029796)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
