### PR TITLE
CBA-104: Remove redundant RoSH summary link

### DIFF
--- a/server/views/applications/pages/risk-of-serious-harm/_risk-of-serious-harm-screen.njk
+++ b/server/views/applications/pages/risk-of-serious-harm/_risk-of-serious-harm-screen.njk
@@ -8,9 +8,6 @@
   <div class="govuk-grid-row" id="{{ pageName }}">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ page.title }}</h1>
-      <a href="{{ paths.applications.pages.show({ id: applicationId, task: 'risk-of-serious-harm', page: 'summary' }) }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19">
-        View RoSH summary
-      </a>
     </div>
   </div>
 


### PR DESCRIPTION
As we’re no longer importing from OASys, we don’t have a RoSH summary page.

# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-104

# Changes in this PR

## Screenshots of UI changes

### Before

![Screenshot 2025-01-14 at 14 21 15](https://github.com/user-attachments/assets/70e195da-9aa0-4a4e-8ed0-d84073a41341)

### After

![Screenshot 2025-01-14 at 14 20 26](https://github.com/user-attachments/assets/2d5ef79d-4fce-4a10-a863-eb15263949ed)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
