### PR TITLE
CBA-105: Only redirect user to legal advisor info if they select legal advisor

### DIFF
--- a/server/form-pages/apply/bail-information/bail-hearing-arrangement/bailHearingArranger.test.ts
+++ b/server/form-pages/apply/bail-information/bail-hearing-arrangement/bailHearingArranger.test.ts
@@ -6,7 +6,16 @@ describe('BailHearingArranger', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
 
   itShouldHavePreviousValue(new BailHearingArranger({}, application), 'taskList')
-  itShouldHaveNextValue(new BailHearingArranger({}, application), 'bail-hearing-contact')
+
+  describe('when legal advisor is selected', () => {
+    itShouldHaveNextValue(
+      new BailHearingArranger({ bailHearingArranger: 'legalAdvisor' }, application),
+      'bail-hearing-contact',
+    )
+  })
+  describe('when legal advisor is not selected', () => {
+    itShouldHaveNextValue(new BailHearingArranger({ bailHearingArranger: 'applicant' }, application), '')
+  })
 
   describe('items', () => {
     it('returns the radio with the expected label text', () => {

--- a/server/form-pages/apply/bail-information/bail-hearing-arrangement/bailHearingArranger.ts
+++ b/server/form-pages/apply/bail-information/bail-hearing-arrangement/bailHearingArranger.ts
@@ -45,7 +45,10 @@ export default class BailHearingArranger implements TaskListPage {
   }
 
   next() {
-    return 'bail-hearing-contact'
+    if (this.body.bailHearingArranger === 'legalAdvisor') {
+      return 'bail-hearing-contact'
+    }
+    return ''
   }
 
   items() {


### PR DESCRIPTION
If the applicant is arranging the bail hearing themselves, we redirect the user back to the task list.

# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-105

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
