### PR TITLE
SECURITY: Update express from 4.21.1 to 4.21.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "date-fns": "^4.1.0",
         "dotenv": "^16.4.5",
         "exceljs": "^4.4.0",
-        "express": "^4.21.1",
+        "express": "^4.21.2",
         "express-session": "^1.18.1",
         "fishery": "^2.2.2",
         "govuk-frontend": "^5.7.1",
@@ -7378,9 +7378,10 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -7401,7 +7402,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -7416,6 +7417,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express-session": {
@@ -7476,9 +7481,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
     "node_modules/express/node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "date-fns": "^4.1.0",
     "dotenv": "^16.4.5",
     "exceljs": "^4.4.0",
-    "express": "^4.21.1",
+    "express": "^4.21.2",
     "express-session": "^1.18.1",
     "fishery": "^2.2.2",
     "govuk-frontend": "^5.7.1",


### PR DESCRIPTION

# Context
Express was using vulnerable version of path-to-regexp. This patch version of express updates path-to-regexp dependency to the newer version which no longer includes the vulnerability.

### Before

```
$ npm run security_audit                                                                                                

> hmpps-community-accommodation-tier-2-bail-ui@0.0.1 security_audit
> npx audit-ci --config audit-ci.json

NPM audit report results:
{
  "advisories": {
    "express": {
      "name": "express",
      "severity": "moderate",
      "isDirect": true,
      "via": [
        "path-to-regexp"
      ],
      "effects": [],
      "range": "4.0.0-rc1 - 4.21.1 || 5.0.0-alpha.1 - 5.0.0-beta.3",
      "nodes": [
        "node_modules/express"
      ],
      "fixAvailable": true
    },
    "path-to-regexp": {
      "name": "path-to-regexp",
      "severity": "moderate",
      "isDirect": false,
      "via": [
        {
          "source": 1101081,
          "name": "path-to-regexp",
          "dependency": "path-to-regexp",
          "title": "Unpatched `path-to-regexp` ReDoS in 0.1.x",
          "url": "https://github.com/advisories/GHSA-rhx6-c78j-4q9w",
          "severity": "moderate",
          "cwe": [
            "CWE-1333"
          ],
          "cvss": {
            "score": 0,
            "vectorString": null
          },
          "range": "<0.1.12"
        }
      ],
      "effects": [
        "express"
      ],
      "range": "<0.1.12",
      "nodes": [
        "node_modules/express/node_modules/path-to-regexp"
      ],
      "fixAvailable": true
    }
  },
  "metadata": {
    "vulnerabilities": {
      "info": 0,
      "low": 0,
      "moderate": 2,
      "high": 0,
      "critical": 0,
      "total": 2
    },
    "dependencies": {
      "prod": 425,
      "dev": 827,
      "optional": 35,
      "peer": 42,
      "peerOptional": 0,
      "total": 1262
    }
  }
}
Found vulnerable advisory paths:
GHSA-rhx6-c78j-4q9w|express>path-to-regexp
Failed security audit due to moderate vulnerabilities.
Vulnerable advisories are:
https://github.com/advisories/GHSA-rhx6-c78j-4q9w
```

### After

```
 $ npm run security_audit               

> hmpps-community-accommodation-tier-2-bail-ui@0.0.1 security_audit
> npx audit-ci --config audit-ci.json

NPM audit report results:
{
  "advisories": {},
  "metadata": {
    "vulnerabilities": {
      "info": 0,
      "low": 0,
      "moderate": 0,
      "high": 0,
      "critical": 0,
      "total": 0
    },
    "dependencies": {
      "prod": 425,
      "dev": 827,
      "optional": 35,
      "peer": 42,
      "peerOptional": 0,
      "total": 1262
    }
  }
}
Passed npm security audit.
```