### PR TITLE
CBA-117 add a new page at the start of add solicitor details task for does the applicant have a solicitor

### DIFF
--- a/e2e-tests/steps/apply.ts
+++ b/e2e-tests/steps/apply.ts
@@ -58,7 +58,7 @@ export const completeBeforeYouStartSection = async (page: Page, name: string) =>
   await completeEligibilityTask(page, name)
   await completeConsentTask(page, name)
   await completeReferrerDetailsTask(page)
-  await completeSolicitorDetailsTask(page)
+  await completeSolicitorDetailsTask(page, name)
 }
 
 export const completeAreaAndFundingSection = async (page: Page, name: string) => {

--- a/e2e-tests/steps/beforeYouStartSection.ts
+++ b/e2e-tests/steps/beforeYouStartSection.ts
@@ -57,11 +57,19 @@ async function completeContactNumberPage(page: Page) {
   await confirmDetailsPage.clickSave()
 }
 
-export const completeSolicitorDetailsTask = async (page: Page) => {
+export const completeSolicitorDetailsTask = async (page: Page, name: string) => {
   const taskListPage = new TaskListPage(page)
   await taskListPage.clickTask('Add solicitor details')
 
+  await completeHasSolicitorPage(page, name)
   await completeSolicitorContactInformationPage(page)
+}
+
+async function completeHasSolicitorPage(page: Page, name: string) {
+  const hasSolicitorPage = await ApplyPage.initialize(page, `Does ${name} have a solicitor?`)
+
+  await hasSolicitorPage.checkRadio('Yes')
+  await hasSolicitorPage.clickSave()
 }
 
 async function completeSolicitorContactInformationPage(page: Page) {

--- a/server/form-pages/apply/before-you-start/solicitor-details/contactInformation.test.ts
+++ b/server/form-pages/apply/before-you-start/solicitor-details/contactInformation.test.ts
@@ -6,7 +6,7 @@ describe('ContactInformation', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
 
   itShouldHaveNextValue(new ContactInformation({}, application), '')
-  itShouldHavePreviousValue(new ContactInformation({}, application), 'taskList')
+  itShouldHavePreviousValue(new ContactInformation({}, application), 'has-solicitor')
 
   describe('errors', () => {
     it('returns an error if fields are are missing', () => {

--- a/server/form-pages/apply/before-you-start/solicitor-details/contactInformation.ts
+++ b/server/form-pages/apply/before-you-start/solicitor-details/contactInformation.ts
@@ -36,7 +36,7 @@ export default class ContactInformation implements TaskListPage {
   }
 
   previous() {
-    return 'taskList'
+    return 'has-solicitor'
   }
 
   next() {

--- a/server/form-pages/apply/before-you-start/solicitor-details/hasSolicitor.test.ts
+++ b/server/form-pages/apply/before-you-start/solicitor-details/hasSolicitor.test.ts
@@ -1,0 +1,55 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import HasSolicitor from './hasSolicitor'
+import { applicationFactory, personFactory } from '../../../../testutils/factories/index'
+import { getQuestions } from '../../../utils/questions'
+
+describe('HasSolicitor', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  const questions = getQuestions('Roger Smith')
+
+  describe('title', () => {
+    it('personalises the page title', () => {
+      const page = new HasSolicitor({ hasSolicitor: 'yes' }, application)
+
+      expect(page.title).toEqual('Does Roger Smith have a solicitor?')
+    })
+  })
+
+  describe('when the person does not have a solicitor', () => {
+    itShouldHaveNextValue(new HasSolicitor({ hasSolicitor: 'no' }, application), '')
+  })
+  describe('when the person does have a solicitor', () => {
+    itShouldHaveNextValue(new HasSolicitor({ hasSolicitor: 'yes' }, application), 'contact-information')
+  })
+  itShouldHavePreviousValue(new HasSolicitor({ hasSolicitor: 'yes' }, application), 'taskList')
+
+  describe('items', () => {
+    it('returns the radio with the expected label text', () => {
+      const page = new HasSolicitor({ hasSolicitor: 'yes' }, application)
+
+      expect(page.items()).toEqual([
+        {
+          value: 'yes',
+          text: questions['solicitor-details']['has-solicitor'].hasSolicitor.answers.yes,
+          checked: true,
+        },
+        {
+          value: 'no',
+          text: questions['solicitor-details']['has-solicitor'].hasSolicitor.answers.no,
+          checked: false,
+        },
+      ])
+    })
+  })
+
+  describe('errors', () => {
+    it('should return errors when yes/no questions are blank', () => {
+      const page = new HasSolicitor({}, application)
+
+      expect(page.errors()).toEqual({
+        hasSolicitor: 'Choose either Yes or No',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/before-you-start/solicitor-details/hasSolicitor.ts
+++ b/server/form-pages/apply/before-you-start/solicitor-details/hasSolicitor.ts
@@ -1,0 +1,64 @@
+import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { Cas2Application as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
+import { nameOrPlaceholderCopy } from '../../../../utils/utils'
+import { getQuestions } from '../../../utils/questions'
+
+type HasSolicitorBody = {
+  hasSolicitor: YesOrNo
+}
+@Page({
+  name: 'has-solicitor',
+  bodyProperties: ['hasSolicitor'],
+})
+export default class HasSolicitor implements TaskListPage {
+  documentTitle = 'Does the person have a solicitor?'
+
+  personName = nameOrPlaceholderCopy(this.application.person)
+
+  title = `Does ${this.personName} have a solicitor?`
+
+  questions: Record<string, string>
+
+  options: Record<string, string>
+
+  body: HasSolicitorBody
+
+  constructor(
+    body: Partial<HasSolicitorBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as HasSolicitorBody
+
+    const applicationQuestions = getQuestions(this.personName)
+    this.questions = {
+      hasSolicitor: applicationQuestions['solicitor-details']['has-solicitor'].hasSolicitor.question,
+    }
+    this.options = applicationQuestions['solicitor-details']['has-solicitor'].hasSolicitor.answers
+  }
+
+  previous() {
+    return 'taskList'
+  }
+
+  next() {
+    if (this.body.hasSolicitor === 'no') {
+      return ''
+    }
+    return 'contact-information'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+    if (!this.body.hasSolicitor) {
+      errors.hasSolicitor = 'Choose either Yes or No'
+    }
+    return errors
+  }
+
+  items() {
+    return convertKeyValuePairToRadioItems(this.options, this.body.hasSolicitor)
+  }
+}

--- a/server/form-pages/apply/before-you-start/solicitor-details/index.ts
+++ b/server/form-pages/apply/before-you-start/solicitor-details/index.ts
@@ -2,10 +2,11 @@
 
 import { Task } from '../../../utils/decorators'
 import ContactInformation from './contactInformation'
+import HasSolicitor from './hasSolicitor'
 
 @Task({
   name: 'Add solicitor details',
   slug: 'solicitor-details',
-  pages: [ContactInformation],
+  pages: [HasSolicitor, ContactInformation],
 })
 export default class SolicitorDetails {}

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -70,6 +70,12 @@ export const getQuestions = (name: string) => {
       },
     },
     'solicitor-details': {
+      'has-solicitor': {
+        hasSolicitor: {
+          question: `Does ${name} have a solicitor?`,
+          answers: yesOrNo,
+        },
+      },
       'contact-information': {
         contactInformation: {
           question: "Add solicitor's contact information",

--- a/server/views/applications/pages/solicitor-details/has-solicitor.njk
+++ b/server/views/applications/pages/solicitor-details/has-solicitor.njk
@@ -1,0 +1,22 @@
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  {{
+    formPageRadios(
+      {
+        fieldset: {
+          legend: {
+            text: page.questions.hasSolicitor,
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        fieldName: "hasSolicitor",
+        items: page.items()
+      },
+      fetchContext()
+    )
+  }}
+
+{% endblock %}


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-117

# Changes in this PR

Adds a new page to the start of the solicitor details task, checking that the applicant has a solicitor. If they do, the referrer continues to the solicitor details. If not, the task is complete and they return to the task list.

## Screenshots of UI changes

![Screenshot 2025-01-21 at 11 42 45](https://github.com/user-attachments/assets/176dc6a4-ec92-4283-8865-2b533a2c952a)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
