### PR TITLE
Allow probation users to start and view applications

### DIFF
--- a/server/utils/userUtils.test.ts
+++ b/server/utils/userUtils.test.ts
@@ -16,6 +16,11 @@ describe('userUtils', () => {
       expect(sectionsForUser(['LICENCE_CA'])).toEqual(expected)
     })
 
+    it('should return correct sections for a probation user', () => {
+      const expected = [sections.applications, sections.newApplication]
+      expect(sectionsForUser(['PROBATION'])).toEqual(expected)
+    })
+
     it('should return correct sections for an admin', () => {
       const expected = [sections.submittedApplications]
       expect(sectionsForUser(['CAS2_ADMIN'])).toEqual(expected)

--- a/server/utils/userUtils.ts
+++ b/server/utils/userUtils.ts
@@ -42,7 +42,7 @@ export const hasRole = (userRoles: Array<string>, role: string): boolean => {
 export const sectionsForUser = (userRoles: Array<string>): Array<ServiceSection> => {
   const items = []
 
-  if (hasRole(userRoles, 'POM') || hasRole(userRoles, 'LICENCE_CA')) {
+  if (hasRole(userRoles, 'POM') || hasRole(userRoles, 'LICENCE_CA') || hasRole(userRoles, 'PROBATION')) {
     items.push(sections.applications)
     items.push(sections.newApplication)
   }


### PR DESCRIPTION
[JIRA](https://dsdmoj.atlassian.net/browse/CBA-47?atlOrigin=eyJpIjoiYWIwNWY5MzM2ZTc0NDE4ZWI1YzU2M2QzNDhkZmU0M2IiLCJwIjoiaiJ9)

# Context
We want probation users to be shown the appropriate tiles on the service home page so that they can create and view applications.

# Changes in this PR
Allow probation users to start and view applications

## Screenshots of UI changes
<img width="1242" alt="Screenshot 2025-01-28 at 14 09 32" src="https://github.com/user-attachments/assets/e1aabbbf-4e75-4470-ac7b-2039e59c6f5a" />

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
