### PR TITLE
Add application type to view application table

### DIFF
--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -595,79 +595,174 @@ describe('getPage', () => {
   })
 
   describe('getApplicantDetails', () => {
-    it('should return applicant details in the correct format', () => {
-      const person = personFactory.build({})
+    describe('when application type is prison bail', () => {
+      it('should return applicant details in the correct format', () => {
+        const person = personFactory.build({})
 
-      const application = applicationFactory.build({ person })
+        const application = applicationFactory.build({ person, applicationOrigin: 'prisonBail' })
 
-      const expected = [
-        {
-          key: {
-            text: 'Full name',
+        const expected = [
+          {
+            key: {
+              text: 'Application type',
+            },
+            value: {
+              html: 'Prison Bail',
+            },
           },
-          value: {
-            html: person.name,
+          {
+            key: {
+              text: 'Full name',
+            },
+            value: {
+              html: person.name,
+            },
           },
-        },
-        {
-          key: {
-            text: 'Date of birth',
+          {
+            key: {
+              text: 'Date of birth',
+            },
+            value: {
+              html: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+            },
           },
-          value: {
-            html: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+          {
+            key: {
+              text: 'Nationality',
+            },
+            value: {
+              html: person.nationality,
+            },
           },
-        },
-        {
-          key: {
-            text: 'Nationality',
+          {
+            key: {
+              text: 'Sex',
+            },
+            value: {
+              html: person.sex,
+            },
           },
-          value: {
-            html: person.nationality,
+          {
+            key: {
+              text: 'Prison number',
+            },
+            value: {
+              html: person.nomsNumber,
+            },
           },
-        },
-        {
-          key: {
-            text: 'Sex',
+          {
+            key: {
+              text: 'Prison',
+            },
+            value: {
+              html: person.prisonName,
+            },
           },
-          value: {
-            html: person.sex,
+          {
+            key: {
+              text: 'PNC number',
+            },
+            value: {
+              html: person.pncNumber,
+            },
           },
-        },
-        {
-          key: {
-            text: 'Prison number',
+          {
+            key: {
+              text: 'CRN from NDelius',
+            },
+            value: {
+              html: person.crn,
+            },
           },
-          value: {
-            html: person.nomsNumber,
-          },
-        },
-        {
-          key: {
-            text: 'Prison',
-          },
-          value: {
-            html: person.prisonName,
-          },
-        },
-        {
-          key: {
-            text: 'PNC number',
-          },
-          value: {
-            html: person.pncNumber,
-          },
-        },
-        {
-          key: {
-            text: 'CRN from NDelius',
-          },
-          value: {
-            html: person.crn,
-          },
-        },
-      ]
+        ]
 
-      expect(getApplicantDetails(application)).toEqual(expected)
+        expect(getApplicantDetails(application)).toEqual(expected)
+      })
+    })
+
+    describe('when application type is court bail', () => {
+      it('should return applicant details in the correct format', () => {
+        const person = personFactory.build({})
+
+        const application = applicationFactory.build({ person, applicationOrigin: 'courtBail' })
+
+        const expected = [
+          {
+            key: {
+              text: 'Application type',
+            },
+            value: {
+              html: 'Court Bail',
+            },
+          },
+          {
+            key: {
+              text: 'Full name',
+            },
+            value: {
+              html: person.name,
+            },
+          },
+          {
+            key: {
+              text: 'Date of birth',
+            },
+            value: {
+              html: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+            },
+          },
+          {
+            key: {
+              text: 'Nationality',
+            },
+            value: {
+              html: person.nationality,
+            },
+          },
+          {
+            key: {
+              text: 'Sex',
+            },
+            value: {
+              html: person.sex,
+            },
+          },
+          {
+            key: {
+              text: 'Prison number',
+            },
+            value: {
+              html: person.nomsNumber,
+            },
+          },
+          {
+            key: {
+              text: 'Prison',
+            },
+            value: {
+              html: person.prisonName,
+            },
+          },
+          {
+            key: {
+              text: 'PNC number',
+            },
+            value: {
+              html: person.pncNumber,
+            },
+          },
+          {
+            key: {
+              text: 'CRN from NDelius',
+            },
+            value: {
+              html: person.crn,
+            },
+          },
+        ]
+
+        expect(getApplicantDetails(application)).toEqual(expected)
+      })
     })
 
     it('should return applicant details with nationality as unknown', () => {
@@ -676,6 +771,14 @@ describe('getPage', () => {
       const application = applicationFactory.build({ person })
 
       const expected = [
+        {
+          key: {
+            text: 'Application type',
+          },
+          value: {
+            html: 'Prison Bail',
+          },
+        },
         {
           key: {
             text: 'Full name',

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -232,6 +232,14 @@ export const getApplicantDetails = (application: Application | Cas2v2SubmittedAp
   return [
     {
       key: {
+        text: 'Application type',
+      },
+      value: {
+        html: application.applicationOrigin === 'courtBail' ? 'Court Bail' : 'Prison Bail',
+      },
+    },
+    {
+      key: {
         text: 'Full name',
       },
       value: {


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-124

# Changes in this PR

Adds application type to the view application table, displayed on the CYA screen as well as the submitted application screens.

NB this is waiting for applicationOrigin to be available as part of the Cas2v2SubmittedApplication, so should not be merged until that API update is in main.

## Screenshots of UI changes

### Before

![Screenshot 2025-01-30 at 11 17 15](https://github.com/user-attachments/assets/6223bfad-5859-4a98-9cd7-d52959a2c828)

### After

![Screenshot 2025-01-30 at 11 16 41](https://github.com/user-attachments/assets/4af19aae-d1d8-43e9-9bac-80c18e6b2201)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
