### PR TITLE
Replace deprecated Faker userName() method

### DIFF
--- a/server/testutils/factories/applicationNote.ts
+++ b/server/testutils/factories/applicationNote.ts
@@ -7,7 +7,7 @@ import { DateFormats } from '../../utils/dateUtils'
 export default Factory.define<Cas2v2ApplicationNote>(() => ({
   id: faker.string.uuid(),
   email: faker.internet.email(),
-  username: faker.internet.userName(),
+  username: faker.internet.username(),
   name: faker.person.fullName(),
   body: faker.lorem.paragraph(),
   createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),

--- a/server/testutils/factories/externalUser.ts
+++ b/server/testutils/factories/externalUser.ts
@@ -4,7 +4,7 @@ import { Factory } from 'fishery'
 
 export default Factory.define<ExternalUser>(() => ({
   id: faker.string.uuid(),
-  username: faker.internet.userName(),
+  username: faker.internet.username(),
   name: faker.person.fullName(),
   email: 'example@example.cas2nacro.org',
   origin: 'NACRO',

--- a/server/testutils/factories/nomisUser.ts
+++ b/server/testutils/factories/nomisUser.ts
@@ -5,7 +5,7 @@ import { Factory } from 'fishery'
 export default Factory.define<NomisUser>(() => ({
   id: faker.string.uuid(),
   name: faker.person.fullName(),
-  nomisUsername: faker.internet.userName(),
+  nomisUsername: faker.internet.username(),
   email: faker.internet.email(),
   isActive: faker.datatype.boolean(),
 }))


### PR DESCRIPTION
# Context

faker.internet.userName() has been deprecated in favour of faker.internet.username() - https://fakerjs.dev/api/internet#username-1.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
