### PR TITLE
Remove google tag manager

### DIFF
--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -8,27 +8,6 @@
 {% block head %}
   <link href="{{ '/assets/css/app.css' | assetMap }}" rel="stylesheet"/>
 
-  {% if tagManagerId %}
-    <!-- Google Tag Manager -->
-    <script nonce="{{ cspNonce }}">
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer'
-            ? '&l=' + l
-            : '';
-        j.async = true;
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-        f
-          .parentNode
-          .insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', "{{ tagManagerId }}");
-    </script>
-    <!-- End Google Tag Manager -->
-  {% endif %}
-
 {% endblock %}
 
 {% block pageTitle %}{{pageTitle | default(applicationName)}}
@@ -67,15 +46,6 @@
   <body>, to avoid blocking the initial render. #}
   <script src="/assets/js/jquery.min.js"></script>
   <script type="module" src="{{ '/assets/js/app.js' | assetMap }}"></script>
-
-  {% if tagManagerId %}
-    <!-- Google Tag Manager (noscript) -->
-    <noscript>
-      <iframe nonce="{{ cspNonce }}" src="{{ tagManagerUrl }}"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
-    <!-- End Google Tag Manager (noscript) -->
-  {% endif %}
 
   {% block extraScripts %}{% endblock %}
 {% endblock %}

--- a/server/views/static/cookies-policy.njk
+++ b/server/views/static/cookies-policy.njk
@@ -28,27 +28,6 @@
           </tr>
         </tbody>
       </table>
-
-      <h2 class="govuk-heading-m">Analytical Cookies (Google Analytics)</h2>
-
-      <p>
-        We use Google Analytics to collect information about how you use {{ applicationName }}. We do this to help make sure the site is meeting the needs of users and to help us make improvements.
-      </p>
-     <p>Google Analytics stores information about:</p>
-      <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
-        <li>the pages you visit</li>
-        <li>how long you spend on each page</li>
-        <li>how you got to the site</li>
-        <li>how you navigate the site</li>
-      </ul>
-
-      <p>
-        We don’t collect or store your personal information (e.g. your name or address) so this information can’t be used to identify who you are.
-      </p>
-      <p>We don’t allow Google to use or share our analytics data.</p>
-      <p>
-        You can <a target="_blank" rel="noreferrer noopener" href="https://tools.google.com/dlpage/gaoptout">opt out of Google Analytics cookies</a>.
-      </p>
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
# Context
This was copied over from CAS2 HDC but is not needed in the new Bail service.