### PR TITLE
Add generate-types GH workflow

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -1,0 +1,33 @@
+name: Generate Types
+
+on:
+  workflow_dispatch:
+
+env:
+  NODE_ENV: test
+  API_CLIENT_ID: approved-premises
+  API_CLIENT_SECRET: clientsecret
+
+jobs:
+  generate-types:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Token
+        uses: tibdex/github-app-token@v2
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Generate Types
+        run: ./script/generate-types
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          title: 'API model updates'
+          commit-message: 'Updating hmpps-approved-premises-api models from OpenAPI specification'
+          body: 'Updating hmpps-approved-premises-api models from OpenAPI specification.  This PR was created automatically from the generate-types.yml Workflow'
+          delete-branch: true
+          branch: update-api-types


### PR DESCRIPTION
This is copied from CAS2 HDC. The APP_ID and APP_PRIVATE_KEY for the GitHub app that manages the CAS type updates have been added to the repo secrets.

# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-141.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
