### PR TITLE
Remove education/training question from funding page

### DIFF
--- a/e2e-tests/steps/areaAndFundingSection.ts
+++ b/e2e-tests/steps/areaAndFundingSection.ts
@@ -10,7 +10,6 @@ export const completeFundingInformationTask = async (page: Page) => {
   await fundingInformationPage.checkRadioInGroup('Does the applicant have a National Insurance number?', 'Yes')
   await fundingInformationPage.checkRadioByTestId('receiving-benefits-radio-yes')
   await fundingInformationPage.checkRadioByTestId('received-benefit-sanctions-radio-yes')
-  await fundingInformationPage.checkRadioInGroup('Is the applicant in education or receiving any training?', 'No')
   await fundingInformationPage.clickSave()
 }
 

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -48,8 +48,7 @@
       "hasNationalInsuranceNumber": "yes",
       "nationalInsuranceNumber": "SF123456X",
       "receivingBenefits": "yes",
-      "receivedBenefitSanctions": "no",
-      "inEducationOrTraining": "no"
+      "receivedBenefitSanctions": "no"
     },
     "applicant-id": {
       "idDocuments": "passport"

--- a/integration_tests/pages/apply/area-and-funding/funding-information/fundingCas2AccommodationPage.ts
+++ b/integration_tests/pages/apply/area-and-funding/funding-information/fundingCas2AccommodationPage.ts
@@ -12,14 +12,12 @@ export default class FundingCas2AccommodationPage extends ApplyPage {
     this.enterFundingSourceDetails()
     this.enterNationalInsuranceNumber()
     this.enterBenefitsDetails()
-    this.selectInEducationOrTraining()
   }
 
   completeWithHousingBenefits(): void {
     this.selectFundingSource('benefits')
     this.enterNationalInsuranceNumber()
     this.enterBenefitsDetails()
-    this.selectInEducationOrTraining()
   }
 
   private selectFundingSource(fundingSource: FundingSources): void {
@@ -38,9 +36,5 @@ export default class FundingCas2AccommodationPage extends ApplyPage {
   private enterBenefitsDetails(): void {
     this.checkRadioByNameAndValue('receivingBenefits', 'yes')
     this.checkRadioByNameAndValue('receivedBenefitSanctions', 'no')
-  }
-
-  private selectInEducationOrTraining(): void {
-    this.checkRadioByNameAndValue('inEducationOrTraining', 'no')
   }
 }

--- a/server/form-pages/apply/area-and-funding/funding-information/fundingCas2Accommodation.test.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/fundingCas2Accommodation.test.ts
@@ -22,7 +22,6 @@ describe('FundingCas2Accommodation', () => {
         nationalInsuranceNumber: 'SF123456X',
         receivingBenefits: 'yes',
         receivedBenefitSanctions: 'no',
-        inEducationOrTraining: 'yes',
       },
       application,
     )
@@ -34,7 +33,6 @@ describe('FundingCas2Accommodation', () => {
       nationalInsuranceNumber: 'SF123456X',
       receivingBenefits: 'yes',
       receivedBenefitSanctions: 'no',
-      inEducationOrTraining: 'yes',
     } as FundingCas2AccommodationBody)
   })
 
@@ -50,7 +48,6 @@ describe('FundingCas2Accommodation', () => {
         fundingSource: 'Select how the applicant will pay for their accommodation and the service charge',
         hasNationalInsuranceNumber: 'Select if the applicant has a National Insurance number',
         receivingBenefits: 'Select if the applicant is currently receiving any benefits',
-        inEducationOrTraining: 'Select if the applicant is currently in education or receiving any training',
       })
     })
 
@@ -64,7 +61,6 @@ describe('FundingCas2Accommodation', () => {
             nationalInsuranceNumber: 'SF123456X',
             receivingBenefits: 'yes',
             receivedBenefitSanctions: null,
-            inEducationOrTraining: 'yes',
           },
           application,
         )
@@ -86,7 +82,6 @@ describe('FundingCas2Accommodation', () => {
           nationalInsuranceNumber: 'SF123456X',
           receivingBenefits: 'no',
           receivedBenefitSanctions: 'yes',
-          inEducationOrTraining: 'yes',
         },
         application,
       )
@@ -97,7 +92,6 @@ describe('FundingCas2Accommodation', () => {
         fundingSource: 'benefits',
         hasNationalInsuranceNumber: 'no',
         receivingBenefits: 'no',
-        inEducationOrTraining: 'yes',
       })
     })
   })

--- a/server/form-pages/apply/area-and-funding/funding-information/fundingCas2Accommodation.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/fundingCas2Accommodation.ts
@@ -18,7 +18,6 @@ export type FundingCas2AccommodationBody = {
   nationalInsuranceNumber: string
   receivingBenefits: YesOrNo
   receivedBenefitSanctions: YesOrNo
-  inEducationOrTraining: YesOrNo
 }
 
 @Page({
@@ -30,7 +29,6 @@ export type FundingCas2AccommodationBody = {
     'nationalInsuranceNumber',
     'receivingBenefits',
     'receivedBenefitSanctions',
-    'inEducationOrTraining',
   ],
 })
 export default class FundingCas2Accommodation implements TaskListPage {
@@ -81,9 +79,6 @@ export default class FundingCas2Accommodation implements TaskListPage {
     if (this.body.receivingBenefits === 'yes' && !this.body.receivedBenefitSanctions) {
       errors.receivedBenefitSanctions =
         'Select if the applicant has received any benefit sanctions in the last 6 months'
-    }
-    if (!this.body.inEducationOrTraining) {
-      errors.inEducationOrTraining = 'Select if the applicant is currently in education or receiving any training'
     }
     return errors
   }

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -436,10 +436,6 @@ export const getQuestions = (name: string) => {
           question: 'Have they received any benefit sanctions in the last 6 months?',
           answers: yesOrNo,
         },
-        inEducationOrTraining: {
-          question: 'Is the applicant in education or receiving any training?',
-          answers: yesOrNo,
-        },
       },
       'applicant-id': {
         idDocuments: {

--- a/server/views/applications/pages/funding-information/funding-cas2-accommodation.njk
+++ b/server/views/applications/pages/funding-information/funding-cas2-accommodation.njk
@@ -169,32 +169,4 @@
     )
   }}
 
-  {{
-    formPageRadios(
-      {
-       fieldset: {
-          legend: {
-            text: page.questions.inEducationOrTraining.question,
-            classes: "govuk-fieldset__legend--m"
-          }
-       },
-       fieldName: 'inEducationOrTraining',
-       label: {
-         text: page.questions.inEducationOrTraining.question
-       },
-       items: [
-         {
-           value: 'yes',
-           text: 'Yes'
-         },
-         {
-           value: 'no',
-           text: 'No'
-         }
-       ]
-      },
-      fetchContext()
-    )
-  }}
-
 {% endblock %}


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-299

# Changes in this PR

Removes the redundant education/training question from the funding page.

## Screenshots of UI changes

### Before

![Screenshot 2025-03-03 at 14 42 28](https://github.com/user-attachments/assets/2b53b636-04df-4f1f-90f9-5f05622412ca)

### After

![Screenshot 2025-03-03 at 14 41 47](https://github.com/user-attachments/assets/9cd79eca-da32-497e-b8e9-cac25ab742ab)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
