### PR TITLE
CBA-303 create gender identity page in applicant details section

### DIFF
--- a/e2e-tests/steps/aboutThePersonSection.ts
+++ b/e2e-tests/steps/aboutThePersonSection.ts
@@ -131,6 +131,17 @@ export const completePersonalInformationTask = async (page: Page, name: string) 
 
   await completeWorkingMobilePhonePage(page, name)
   await completeImmigrationStatusPage(page, name)
+  await completeGenderPage(page, name)
+}
+
+async function completeGenderPage(page: Page, name: string) {
+  const genderPage = await ApplyPage.initialize(
+    page,
+    `Is the gender ${name} identifies with the same as the sex registered at birth?`,
+  )
+
+  await genderPage.checkRadio('Yes')
+  await genderPage.clickSave()
 }
 
 async function completeWorkingMobilePhonePage(page: Page, name: string) {

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -74,6 +74,10 @@
     "immigration-status": {
       "immigrationStatus": "UK citizen"
     },
+    "gender": {
+      "gender": "no",
+      "genderIdentity": "Non binary"
+    },
     "pregnancy-information": {
       "isPregnant": "yes",
       "dueDate-day": "5",

--- a/integration_tests/pages/apply/about_the_person/personal_information/genderPage.ts
+++ b/integration_tests/pages/apply/about_the_person/personal_information/genderPage.ts
@@ -1,0 +1,30 @@
+import { Cas2v2Application as Application } from '@approved-premises/api'
+import ApplyPage from '../../applyPage'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+import paths from '../../../../../server/paths/apply'
+
+export default class GenderPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `Is the gender ${nameOrPlaceholderCopy(application.person)} identifies with the same as the sex registered at birth?`,
+      application,
+      'personal-information',
+      'gender',
+    )
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'personal-information',
+        page: 'gender',
+      }),
+    )
+  }
+
+  completeForm(): void {
+    this.checkRadioByNameAndValue('gender', 'no')
+    this.getTextInputByIdAndEnterDetails('genderIdentity', 'Non binary')
+  }
+}

--- a/integration_tests/pages/apply/about_the_person/personal_information/immigrationStatusPage.ts
+++ b/integration_tests/pages/apply/about_the_person/personal_information/immigrationStatusPage.ts
@@ -1,0 +1,29 @@
+import { Cas2v2Application as Application } from '@approved-premises/api'
+import ApplyPage from '../../applyPage'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+import paths from '../../../../../server/paths/apply'
+
+export default class ImmigrationStatusPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `What is ${nameOrPlaceholderCopy(application.person)}'s immigration status?`,
+      application,
+      'personal-information',
+      'immigration-status',
+    )
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'personal-information',
+        page: 'immigration-status',
+      }),
+    )
+  }
+
+  completeForm(): void {
+    this.getSelectInputByIdAndSelectAnEntry('immigrationStatus', 'UK citizen')
+  }
+}

--- a/integration_tests/pages/apply/about_the_person/personal_information/pregnancyInformationPage.ts
+++ b/integration_tests/pages/apply/about_the_person/personal_information/pregnancyInformationPage.ts
@@ -1,0 +1,30 @@
+import { Cas2v2Application as Application } from '@approved-premises/api'
+import ApplyPage from '../../applyPage'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+import paths from '../../../../../server/paths/apply'
+
+export default class PregnancyInformationPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `Is ${nameOrPlaceholderCopy(application.person)} pregnant?`,
+      application,
+      'personal-information',
+      'pregnancy-information',
+    )
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'personal-information',
+        page: 'pregnancy-information',
+      }),
+    )
+  }
+
+  completeForm(): void {
+    this.checkRadioByNameAndValue('isPregnant', 'yes')
+    this.completeDateInputs('dueDate', '2023-07-15')
+  }
+}

--- a/integration_tests/pages/apply/about_the_person/personal_information/supportWorkerPreferencePage.ts
+++ b/integration_tests/pages/apply/about_the_person/personal_information/supportWorkerPreferencePage.ts
@@ -1,0 +1,30 @@
+import { Cas2v2Application as Application } from '@approved-premises/api'
+import ApplyPage from '../../applyPage'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+import paths from '../../../../../server/paths/apply'
+
+export default class SupportWorkerPreferencePage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `Does ${nameOrPlaceholderCopy(application.person)} have a gender preference for their support worker?`,
+      application,
+      'personal-information',
+      'support-worker-preference',
+    )
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'personal-information',
+        page: 'support-worker-preference',
+      }),
+    )
+  }
+
+  completeForm(): void {
+    this.checkRadioByNameAndValue('hasSupportWorkerPreference', 'yes')
+    this.checkRadioByNameAndValue('supportWorkerPreference', 'female')
+  }
+}

--- a/integration_tests/pages/apply/about_the_person/personal_information/workingMobilePhonePage.ts
+++ b/integration_tests/pages/apply/about_the_person/personal_information/workingMobilePhonePage.ts
@@ -6,7 +6,7 @@ import paths from '../../../../../server/paths/apply'
 export default class WorkingMobilePhonePage extends ApplyPage {
   constructor(private readonly application: Application) {
     super(
-      `Will ${nameOrPlaceholderCopy(application.person)} have a working mobile phone when they are released?`,
+      `Will ${nameOrPlaceholderCopy(application.person)} have a working mobile phone?`,
       application,
       'personal-information',
       'working-mobile-phone',

--- a/integration_tests/pages/apply/about_the_person/personal_information/workingMobilePhonePage.ts
+++ b/integration_tests/pages/apply/about_the_person/personal_information/workingMobilePhonePage.ts
@@ -1,0 +1,31 @@
+import { Cas2v2Application as Application } from '@approved-premises/api'
+import ApplyPage from '../../applyPage'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+import paths from '../../../../../server/paths/apply'
+
+export default class WorkingMobilePhonePage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `Will ${nameOrPlaceholderCopy(application.person)} have a working mobile phone when they are released?`,
+      application,
+      'personal-information',
+      'working-mobile-phone',
+    )
+  }
+
+  static visit(application: Application): void {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'personal-information',
+        page: 'working-mobile-phone',
+      }),
+    )
+  }
+
+  completeForm(): void {
+    this.checkRadioByNameAndValue('hasWorkingMobilePhone', 'yes')
+    this.getTextInputByIdAndEnterDetails('mobilePhoneNumber', '11111111111')
+    this.checkRadioByNameAndValue('isSmartPhone', 'yes')
+  }
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -94,6 +94,10 @@ export default abstract class Page {
   clickRemove(): void {
     cy.get('a').contains('Remove').click()
   }
+  
+  getSelectInputByIdAndSelectAnEntry(id: string, entry: string): void {
+    cy.get(`#${id}`).select(entry)
+  }
 
   completeDateInputs(prefix: string, date: string): void {
     const parsedDate = DateFormats.isoToDateObj(date)

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -94,7 +94,7 @@ export default abstract class Page {
   clickRemove(): void {
     cy.get('a').contains('Remove').click()
   }
-  
+
   getSelectInputByIdAndSelectAnEntry(id: string, entry: string): void {
     cy.get(`#${id}`).select(entry)
   }

--- a/integration_tests/tests/apply/about_the_person/personal-information/gender.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/personal-information/gender.cy.ts
@@ -1,0 +1,138 @@
+//  Feature: Referrer completes 'gender' page
+//    So that I can complete the "personal information" task
+//    As a referrer
+//    I want to complete the 'gender' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I visit the 'gender' page
+//
+//  Scenario: view 'gender' page
+//    Then I see the "gender" page
+//
+//  Scenario: navigate to the task list if the applicant is male
+//    Given the applicant is male
+//    When I complete the "gender" page
+//    And I continue to the next task / page
+//    Then I am taken to the task list page
+//
+//  Scenario: navigate to the pregnancy information page if the applicant is not male
+//    Given the applicant is female
+//    When I complete the "gender" page
+//    And I continue to the next task / page
+//    Then I am taken to the pregnancy information page
+
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import GenderPage from '../../../../pages/apply/about_the_person/personal_information/genderPage'
+import TaskListPage from '../../../../pages/apply/taskListPage'
+import PregnancyInformationPage from '../../../../pages/apply/about_the_person/personal_information/pregnancyInformationPage'
+
+context('Visit "gender" page with male applicant', () => {
+  const male = personFactory.build({ name: 'Roger Smith', sex: 'Male' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      delete applicationData['personal-information'].gender
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person: male,
+        data: applicationData,
+      })
+      cy.wrap(application).as('maleApplication')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.maleApplication })
+    cy.task('stubApplicationUpdate', { application: this.maleApplication })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I visit the 'gender' page
+    // --------------------------------
+    GenderPage.visit(this.maleApplication)
+  })
+
+  //  Scenario: view 'gender' page
+  // ----------------------------------------------
+
+  it('presents gender page', function test() {
+    //  Then I see the "gender" page
+    Page.verifyOnPage(GenderPage, this.maleApplication)
+  })
+
+  //  Scenario: navigate to the task list page if the applicant is male
+  // ----------------------------------------------
+  it('navigates to the task list page', function test() {
+    //    Given the applicant is male
+
+    //    When I complete the "gender" page
+    const page = Page.verifyOnPage(GenderPage, this.maleApplication)
+    page.completeForm()
+
+    //    When I continue to the next task / page
+    page.clickSubmit()
+
+    //    Then I am taken to the task list page
+    Page.verifyOnPage(TaskListPage, this.maleApplication)
+  })
+})
+
+context('Visit "gender" page with female applicant', () => {
+  const female = personFactory.build({ name: 'Rogella Smith', sex: 'Female' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      delete applicationData['personal-information'].gender
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person: female,
+        data: applicationData,
+      })
+      cy.wrap(application).as('femaleApplication')
+    })
+  })
+
+  beforeEach(function test() {
+    // And a female application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.femaleApplication })
+    cy.task('stubApplicationUpdate', { application: this.femaleApplication })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I visit the 'gender' page
+    // --------------------------------
+    GenderPage.visit(this.femaleApplication)
+  })
+
+  //  Scenario: navigate to the pregnancy information page if the applicant is not male
+  // ----------------------------------------------
+  it('navigates to the pregnancy information page', function test() {
+    //    When I complete the "gender" page
+    const page = Page.verifyOnPage(GenderPage, this.femaleApplication)
+    page.completeForm()
+
+    //    When I continue to the next task / page
+    page.clickSubmit()
+
+    //    Then I am taken to the pregnancy information page
+    Page.verifyOnPage(PregnancyInformationPage, this.femaleApplication)
+  })
+})

--- a/integration_tests/tests/apply/about_the_person/personal-information/immigration_status.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/personal-information/immigration_status.cy.ts
@@ -11,24 +11,18 @@
 //  Scenario: view 'immigration status' page
 //    Then I see the "immigration status" page
 //
-//  Scenario: navigate to the task list if the applicant is male
+//  Scenario: navigate to the gender page
 //    When I complete the "immigration status" page
 //    And I continue to the next task / page
-//    Then I am taken to the task list page
-//
-//  Scenario: navigate to the pregnancy information page if the applicant is not male
-//    When I complete the "immigration status" page
-//    And I continue to the next task / page
-//    Then I am taken to the pregnancy information page
+//    Then I am taken to the gender page
 
 import Page from '../../../../pages/page'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 import ImmigrationStatusPage from '../../../../pages/apply/about_the_person/personal_information/immigrationStatusPage'
-import PregnancyInformationPage from '../../../../pages/apply/about_the_person/personal_information/pregnancyInformationPage'
-import TaskListPage from '../../../../pages/apply/taskListPage'
+import GenderPage from '../../../../pages/apply/about_the_person/personal_information/genderPage'
 
-context('Visit "immigration status" page - when the applicant is a male', () => {
-  const person = personFactory.build({ name: 'Roger Smith', sex: 'Male' })
+context('Visit "immigration status" page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
 
   beforeEach(function test() {
     cy.task('reset')
@@ -69,9 +63,9 @@ context('Visit "immigration status" page - when the applicant is a male', () => 
     Page.verifyOnPage(ImmigrationStatusPage, this.application)
   })
 
-  //  Scenario: navigate to the task list if the applicant is male
+  //  Scenario: navigate to the gender page
   // ----------------------------------------------
-  it('navigates to the task list if the applicant is male', function test() {
+  it('navigates to the gender page', function test() {
     //    When I complete the "immigration status" page
     const page = Page.verifyOnPage(ImmigrationStatusPage, this.application)
     page.completeForm()
@@ -79,60 +73,7 @@ context('Visit "immigration status" page - when the applicant is a male', () => 
     //    When I continue to the next task / page
     page.clickSubmit()
 
-    //    Then I am taken to the task list next page
-    Page.verifyOnPage(TaskListPage, this.application)
-  })
-})
-
-context('Visit "immigration status" page - when the applicant is not a male', () => {
-  const person = personFactory.build({ name: 'Rose Smith', sex: 'Female' })
-
-  beforeEach(function test() {
-    cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-
-    cy.fixture('applicationData.json').then(applicationData => {
-      delete applicationData['immigration-status']
-      const application = applicationFactory.build({
-        id: 'abc123',
-        person,
-        data: applicationData,
-      })
-      cy.wrap(application).as('application')
-    })
-  })
-
-  beforeEach(function test() {
-    // And an application exists
-    // -------------------------
-    cy.task('stubApplicationGet', { application: this.application })
-    cy.task('stubApplicationUpdate', { application: this.application })
-
-    // Given I am logged in
-    //---------------------
-    cy.signIn()
-
-    // And I visit the 'immigration status' page
-    // --------------------------------
-    ImmigrationStatusPage.visit(this.application)
-  })
-
-  //  Scenario: navigate to the pregnancy information page if the applicant is not male
-  // ----------------------------------------------
-  it('navigates to the task list if the applicant is not male', function test() {
-    // And I visit the 'immigration status' page
-    // --------------------------------
-    ImmigrationStatusPage.visit(this.application)
-
-    //    When I complete the "immigration status" page
-    const page = Page.verifyOnPage(ImmigrationStatusPage, this.application)
-    page.completeForm()
-
-    //    When I continue to the next task / page
-    page.clickSubmit()
-
-    //    Then I am taken to the pregnancy information page
-    Page.verifyOnPage(PregnancyInformationPage, this.application)
+    //    Then I am taken to the gender page
+    Page.verifyOnPage(GenderPage, this.application)
   })
 })

--- a/integration_tests/tests/apply/about_the_person/personal-information/immigration_status.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/personal-information/immigration_status.cy.ts
@@ -1,0 +1,138 @@
+//  Feature: Referrer completes 'immigration status' page
+//    So that I can complete the "immigration status" task
+//    As a referrer
+//    I want to complete the 'immigration status' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I visit the 'immigration status' page
+//
+//  Scenario: view 'immigration status' page
+//    Then I see the "immigration status" page
+//
+//  Scenario: navigate to the task list if the applicant is male
+//    When I complete the "immigration status" page
+//    And I continue to the next task / page
+//    Then I am taken to the task list page
+//
+//  Scenario: navigate to the pregnancy information page if the applicant is not male
+//    When I complete the "immigration status" page
+//    And I continue to the next task / page
+//    Then I am taken to the pregnancy information page
+
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import ImmigrationStatusPage from '../../../../pages/apply/about_the_person/personal_information/immigrationStatusPage'
+import PregnancyInformationPage from '../../../../pages/apply/about_the_person/personal_information/pregnancyInformationPage'
+import TaskListPage from '../../../../pages/apply/taskListPage'
+
+context('Visit "immigration status" page - when the applicant is a male', () => {
+  const person = personFactory.build({ name: 'Roger Smith', sex: 'Male' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      delete applicationData['immigration-status']
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I visit the 'immigration status' page
+    // --------------------------------
+    ImmigrationStatusPage.visit(this.application)
+  })
+
+  //  Scenario: view 'immigration status' page
+  // ----------------------------------------------
+
+  it('presents immigration status page', function test() {
+    //    Then I see the "immigration status" page
+    Page.verifyOnPage(ImmigrationStatusPage, this.application)
+  })
+
+  //  Scenario: navigate to the task list if the applicant is male
+  // ----------------------------------------------
+  it('navigates to the task list if the applicant is male', function test() {
+    //    When I complete the "immigration status" page
+    const page = Page.verifyOnPage(ImmigrationStatusPage, this.application)
+    page.completeForm()
+
+    //    When I continue to the next task / page
+    page.clickSubmit()
+
+    //    Then I am taken to the task list next page
+    Page.verifyOnPage(TaskListPage, this.application)
+  })
+})
+
+context('Visit "immigration status" page - when the applicant is not a male', () => {
+  const person = personFactory.build({ name: 'Rose Smith', sex: 'Female' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      delete applicationData['immigration-status']
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I visit the 'immigration status' page
+    // --------------------------------
+    ImmigrationStatusPage.visit(this.application)
+  })
+
+  //  Scenario: navigate to the pregnancy information page if the applicant is not male
+  // ----------------------------------------------
+  it('navigates to the task list if the applicant is not male', function test() {
+    // And I visit the 'immigration status' page
+    // --------------------------------
+    ImmigrationStatusPage.visit(this.application)
+
+    //    When I complete the "immigration status" page
+    const page = Page.verifyOnPage(ImmigrationStatusPage, this.application)
+    page.completeForm()
+
+    //    When I continue to the next task / page
+    page.clickSubmit()
+
+    //    Then I am taken to the pregnancy information page
+    Page.verifyOnPage(PregnancyInformationPage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/about_the_person/personal-information/pregnancy_information.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/personal-information/pregnancy_information.cy.ts
@@ -1,0 +1,79 @@
+//  Feature: Referrer completes 'pregnancy information' page
+//    So that I can complete the "pregnancy information" task
+//    As a referrer
+//    I want to complete the 'pregnancy information' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I visit the 'pregnancy information' page
+//
+//  Scenario: view 'pregnancy information' page
+//    Then I see the "pregnancy information" page
+//
+//  Scenario: navigate to the support worker preference page
+//    When I complete the "pregnancy information" page
+//    And I continue to the next task / page
+//    Then I am taken to the support worker preference page
+
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import PregnancyInformationPage from '../../../../pages/apply/about_the_person/personal_information/pregnancyInformationPage'
+import SupportWorkerPreferencePage from '../../../../pages/apply/about_the_person/personal_information/supportWorkerPreferencePage'
+
+context('Visit "pregnancy information" page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      delete applicationData['personal-information']['pregnancy-information']
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I visit the 'pregnancy information' page
+    // --------------------------------
+    PregnancyInformationPage.visit(this.application)
+  })
+
+  //  Scenario: view 'pregnancy information' page
+  // ----------------------------------------------
+
+  it('presents pregnancy information page', function test() {
+    //    Then I see the "pregnancy information" page
+    Page.verifyOnPage(PregnancyInformationPage, this.application)
+  })
+
+  //  Scenario: navigate to the support worker preference page
+  // ----------------------------------------------
+  it('navigates to the support worker preference page', function test() {
+    //    When I complete the "pregnancy information" page
+    const page = Page.verifyOnPage(PregnancyInformationPage, this.application)
+    page.completeForm()
+
+    //    When I continue to the next task / page
+    page.clickSubmit()
+
+    //    Then I am taken to the support worker preference next page
+    Page.verifyOnPage(SupportWorkerPreferencePage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/about_the_person/personal-information/support_worker_preference.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/personal-information/support_worker_preference.cy.ts
@@ -11,7 +11,7 @@
 //  Scenario: view 'support worker preference' page
 //    Then I see the "support worker preference" page
 //
-//  Scenario: navigate to the task list page
+//  Scenario: navigate to the next page
 //    When I complete the "support worker preference" page
 //    And I continue to the next task / page
 //    Then I am taken to the task list page
@@ -63,9 +63,9 @@ context('Visit "support worker preference" page', () => {
     Page.verifyOnPage(SupportWorkerPreferencePage, this.application)
   })
 
-  //  Scenario: navigate to the task list page
+  //  Scenario: navigate to the next page
   // ----------------------------------------------
-  it('navigates to the support worker preference page', function test() {
+  it('navigates to the task list page', function test() {
     //    When I complete the "support worker preference" page
     const page = Page.verifyOnPage(SupportWorkerPreferencePage, this.application)
     page.completeForm()

--- a/integration_tests/tests/apply/about_the_person/personal-information/support_worker_preference.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/personal-information/support_worker_preference.cy.ts
@@ -1,0 +1,79 @@
+//  Feature: Referrer completes 'support worker preference' page
+//    So that I can complete the "support worker preference" task
+//    As a referrer
+//    I want to complete the 'support worker preference' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I visit the 'support worker preference' page
+//
+//  Scenario: view 'support worker preference' page
+//    Then I see the "support worker preference" page
+//
+//  Scenario: navigate to the task list page
+//    When I complete the "support worker preference" page
+//    And I continue to the next task / page
+//    Then I am taken to the task list page
+
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import SupportWorkerPreferencePage from '../../../../pages/apply/about_the_person/personal_information/supportWorkerPreferencePage'
+import TaskListPage from '../../../../pages/apply/taskListPage'
+
+context('Visit "support worker preference" page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      delete applicationData['personal-information']['support-worker-preference']
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I visit the 'support worker preference' page
+    // --------------------------------
+    SupportWorkerPreferencePage.visit(this.application)
+  })
+
+  //  Scenario: view 'support worker preference' page
+  // ----------------------------------------------
+
+  it('presents support worker preference page', function test() {
+    //    Then I see the "support worker preference" page
+    Page.verifyOnPage(SupportWorkerPreferencePage, this.application)
+  })
+
+  //  Scenario: navigate to the task list page
+  // ----------------------------------------------
+  it('navigates to the support worker preference page', function test() {
+    //    When I complete the "support worker preference" page
+    const page = Page.verifyOnPage(SupportWorkerPreferencePage, this.application)
+    page.completeForm()
+
+    //    When I continue to the next task / page
+    page.clickSubmit()
+
+    //    Then I am taken to the task list page
+    Page.verifyOnPage(TaskListPage, this.application)
+  })
+})

--- a/integration_tests/tests/apply/about_the_person/personal-information/working_mobile_phone.cy.ts
+++ b/integration_tests/tests/apply/about_the_person/personal-information/working_mobile_phone.cy.ts
@@ -1,0 +1,79 @@
+//  Feature: Referrer completes 'working mobile phone' page
+//    So that I can complete the "working mobile phone" task
+//    As a referrer
+//    I want to complete the 'working mobile phone' page
+//
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I visit the 'working mobile phone' page
+//
+//  Scenario: view 'working mobile phone' page
+//    Then I see the "working mobile phone" page
+//
+//  Scenario: navigate to the next page on completion of task
+//    When I complete the "working mobile phone" page
+//    And I continue to the next task / page
+//    Then I am taken to the immigration status page
+
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import WorkingMobilePhonePage from '../../../../pages/apply/about_the_person/personal_information/workingMobilePhonePage'
+import ImmigrationStatusPage from '../../../../pages/apply/about_the_person/personal_information/immigrationStatusPage'
+
+context('Visit "working mobile phone" page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      delete applicationData['working-mobile-phone']
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+
+    // And I visit the 'working mobile phone' page
+    // --------------------------------
+    WorkingMobilePhonePage.visit(this.application)
+  })
+
+  //  Scenario: view 'working mobile phone' page
+  // ----------------------------------------------
+
+  it('presents working mobile phone page', function test() {
+    //    Then I see the "working mobile phone" page
+    Page.verifyOnPage(WorkingMobilePhonePage, this.application)
+  })
+
+  //  Scenario: navigate to the next page
+  // ----------------------------------------------
+  it('navigates to the next page', function test() {
+    //    When I complete the "working mobile phone" page
+    const page = Page.verifyOnPage(WorkingMobilePhonePage, this.application)
+    page.completeForm()
+
+    //    When I continue to the next task / page
+    page.clickSubmit()
+
+    //    Then I am taken to the immigration status next page
+    Page.verifyOnPage(ImmigrationStatusPage, this.application)
+  })
+})

--- a/server/form-pages/apply/about-the-person/personal-information/gender.test.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/gender.test.ts
@@ -1,0 +1,76 @@
+import { itShouldHavePreviousValue } from '../../../shared-examples'
+import Gender, { GenderBody } from './gender'
+import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
+import { isPersonMale } from '../../../../utils/personUtils'
+
+jest.mock('../../../../utils/personUtils')
+
+describe('Gender', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Sue Smith' }) })
+
+  const body: GenderBody = {
+    gender: 'no',
+    genderIdentity: 'Non-binary',
+  }
+
+  it('sets the body', () => {
+    const page = new Gender(body, application)
+
+    expect(page.body).toEqual(body)
+  })
+
+  describe('errors', () => {
+    it('returns an error if gender is not set', () => {
+      const page = new Gender({ gender: null }, application)
+
+      expect(page.errors()).toEqual({
+        gender: `Choose either Yes, No or Prefer not to say`,
+      })
+    })
+  })
+
+  describe('next', () => {
+    beforeEach(() => {
+      ;(isPersonMale as jest.Mock).mockReset()
+    })
+
+    describe('when the applicant is male', () => {
+      it('should not return a page name', () => {
+        ;(isPersonMale as jest.Mock).mockImplementation(() => true)
+
+        const page = new Gender(body, application)
+
+        expect(page.next()).toEqual('')
+      })
+    })
+
+    describe('when the applicant is not male', () => {
+      it('should return pregnancy information page name', () => {
+        ;(isPersonMale as jest.Mock).mockImplementation(() => false)
+
+        const page = new Gender(body, application)
+
+        expect(page.next()).toEqual('pregnancy-information')
+      })
+    })
+  })
+
+  itShouldHavePreviousValue(new Gender(body, application), 'support-worker-preference')
+
+  describe('onSave', () => {
+    it('removes gender identity data if question is not set to "yes"', () => {
+      const pageBody: GenderBody = {
+        gender: 'preferNotToSay',
+        genderIdentity: 'Man',
+      }
+
+      const page = new Gender(pageBody, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        gender: 'preferNotToSay',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/about-the-person/personal-information/gender.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/gender.ts
@@ -1,0 +1,64 @@
+import { Cas2v2Application as Application } from '@approved-premises/api'
+import { TaskListErrors, YesOrNoOrPreferNotToSay } from '@approved-premises/ui'
+import { nameOrPlaceholderCopy } from '../../../../utils/utils'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+import { getQuestions } from '../../../utils/questions'
+import { isPersonMale } from '../../../../utils/personUtils'
+
+export type GenderBody = {
+  gender: YesOrNoOrPreferNotToSay
+  genderIdentity: string
+}
+
+@Page({
+  name: 'gender',
+  bodyProperties: ['gender', 'genderIdentity'],
+})
+export default class Gender implements TaskListPage {
+  documentTitle = 'Is the gender the person identifies with the same as the sex registered at birth?'
+
+  personName = nameOrPlaceholderCopy(this.application.person)
+
+  title
+
+  questions = getQuestions(this.personName)['personal-information'].gender
+
+  body: GenderBody
+
+  constructor(
+    body: Partial<GenderBody>,
+    private readonly application: Application,
+  ) {
+    this.body = body as GenderBody
+    this.title = this.questions.gender.question
+  }
+
+  previous() {
+    return 'support-worker-preference'
+  }
+
+  next() {
+    if (isPersonMale(this.application.person)) {
+      return ''
+    }
+
+    return 'pregnancy-information'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.gender) {
+      errors.gender = `Choose either Yes, No or Prefer not to say`
+    }
+
+    return errors
+  }
+
+  onSave(): void {
+    if (this.body.gender !== 'yes') {
+      delete this.body.genderIdentity
+    }
+  }
+}

--- a/server/form-pages/apply/about-the-person/personal-information/immigrationStatus.test.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/immigrationStatus.test.ts
@@ -1,9 +1,6 @@
-import { itShouldHavePreviousValue } from '../../../shared-examples'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import ImmigrationStatus, { ImmigrationStatusBody } from './immigrationStatus'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
-import { isPersonMale } from '../../../../utils/personUtils'
-
-jest.mock('../../../../utils/personUtils')
 
 describe('ImmigrationStatus', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Sue Smith' }) })
@@ -34,31 +31,6 @@ describe('ImmigrationStatus', () => {
     })
   })
 
-  describe('next', () => {
-    beforeEach(() => {
-      ;(isPersonMale as jest.Mock).mockReset()
-    })
-
-    describe('when the applicant is male', () => {
-      it('should not return a page name', () => {
-        ;(isPersonMale as jest.Mock).mockImplementation(() => true)
-
-        const page = new ImmigrationStatus(body, application)
-
-        expect(page.next()).toEqual('')
-      })
-    })
-
-    describe('when the applicant is not male', () => {
-      it('should not return pregnancy information page name', () => {
-        ;(isPersonMale as jest.Mock).mockImplementation(() => false)
-
-        const page = new ImmigrationStatus(body, application)
-
-        expect(page.next()).toEqual('pregnancy-information')
-      })
-    })
-  })
-
+  itShouldHaveNextValue(new ImmigrationStatus(body, application), 'gender')
   itShouldHavePreviousValue(new ImmigrationStatus(body, application), 'working-mobile-phone')
 })

--- a/server/form-pages/apply/about-the-person/personal-information/immigrationStatus.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/immigrationStatus.ts
@@ -4,7 +4,6 @@ import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 import { getQuestions } from '../../../utils/questions'
-import { isPersonMale } from '../../../../utils/personUtils'
 
 export type ImmigrationStatusBody = {
   immigrationStatus: string
@@ -62,11 +61,7 @@ export default class ImmigrationStatus implements TaskListPage {
   }
 
   next() {
-    if (isPersonMale(this.application.person)) {
-      return ''
-    }
-
-    return 'pregnancy-information'
+    return 'gender'
   }
 
   errors() {

--- a/server/form-pages/apply/about-the-person/personal-information/index.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/index.ts
@@ -5,10 +5,11 @@ import WorkingMobilePhone from './workingMobilePhone'
 import ImmigrationStatus from './immigrationStatus'
 import PregnancyInformation from './pregnancyInformation'
 import SupportWorkerPreference from './supportWorkerPreference'
+import Gender from './gender'
 
 @Task({
   name: 'Add personal information',
   slug: 'personal-information',
-  pages: [WorkingMobilePhone, ImmigrationStatus, PregnancyInformation, SupportWorkerPreference],
+  pages: [WorkingMobilePhone, ImmigrationStatus, Gender, PregnancyInformation, SupportWorkerPreference],
 })
 export default class PersonalInformation {}

--- a/server/form-pages/apply/about-the-person/personal-information/pregnancyInformation.test.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/pregnancyInformation.test.ts
@@ -46,7 +46,7 @@ describe('PregnancyInformation', () => {
   })
 
   itShouldHaveNextValue(new PregnancyInformation(body, application), 'support-worker-preference')
-  itShouldHavePreviousValue(new PregnancyInformation(body, application), 'immigration-status')
+  itShouldHavePreviousValue(new PregnancyInformation(body, application), 'gender')
 
   describe('response', () => {
     it('returns the pregnancy information', () => {

--- a/server/form-pages/apply/about-the-person/personal-information/pregnancyInformation.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/pregnancyInformation.ts
@@ -37,7 +37,7 @@ export default class PregnancyInformation implements TaskListPage {
   }
 
   previous() {
-    return 'immigration-status'
+    return 'gender'
   }
 
   next() {

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -133,6 +133,19 @@ export const getQuestions = (name: string) => {
           answers: { male: 'Male', female: 'Female' },
         },
       },
+      gender: {
+        gender: {
+          question: `Is the gender ${name} identifies with the same as the sex registered at birth?`,
+          answers: {
+            yes: 'Yes',
+            no: 'No',
+            preferNotToSay: 'Prefer not to say',
+          },
+        },
+        genderIdentity: {
+          question: 'What is their gender identity? (optional)',
+        },
+      },
     },
     'address-history': {
       'previous-address': {

--- a/server/views/applications/pages/personal-information/gender.njk
+++ b/server/views/applications/pages/personal-information/gender.njk
@@ -1,0 +1,59 @@
+{% extends "../layout.njk" %}
+
+{% block questions %}
+  {% set genderDetailHtml %}
+
+    {{
+      formPageInput(
+        {
+          fieldName: "genderIdentity",
+          label: {
+            text: page.questions.genderIdentity.question,
+            classes: "govuk-label"
+          },
+          classes: "govuk-input--width-10"
+        },
+        fetchContext()
+      )
+    }}
+
+  {% endset %}
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "gender",
+        fieldset: {
+          legend: {
+            text: page.questions.gender.question,
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
+          }
+        },
+        hint: {
+            text: "This information helps make sure that the applicant can be placed in appropriate accommodation."
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes"
+          },
+          {
+            value: "no",
+            text: "No",
+            conditional: { html: genderDetailHtml }
+          },
+          {
+            divider: 'or'
+          },
+          {
+            value: "preferNotToSay",
+            text: "Prefer not to say"
+          }
+        ]
+      },
+      fetchContext()
+    )
+  }}
+{% endblock %}
+


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-303

# Changes in this PR

Adds a new gender page to the personal information task, which presents after immigration status and before the two pages that are shown only for female applicants.

## Screenshots of UI changes

![Screenshot 2025-03-04 at 13 41 52](https://github.com/user-attachments/assets/ab39af3f-7440-4749-a467-93a9471fb58a)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
