### PR TITLE
CBA-280: add content to liaison and diversion assessment page

### DIFF
--- a/e2e-tests/steps/risksAndNeedsSection.ts
+++ b/e2e-tests/steps/risksAndNeedsSection.ts
@@ -103,9 +103,9 @@ async function completeBrainInjuryPage(page: Page, name: string) {
 }
 
 async function completeLiaisonAndDiversionPage(page: Page, name: string) {
-  const liaisonAndDiversionPage = await ApplyPage.initialize(page, `Liaison & Diversion Assessment for ${name}`)
+  const liaisonAndDiversionPage = await ApplyPage.initialize(page, `Liaison and Diversion Assessment for ${name}`)
 
-  await liaisonAndDiversionPage.checkRadioInGroup('Liaison & Diversion Assessment', 'No')
+  await liaisonAndDiversionPage.checkRadioInGroup('Liaison and Diversion Assessment', 'No')
 
   await liaisonAndDiversionPage.clickSave()
 }

--- a/integration_tests/pages/apply/risks_and_needs/health-needs/brainInjuryPage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/health-needs/brainInjuryPage.ts
@@ -1,7 +1,7 @@
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import ApplyPage from '../../applyPage'
 import paths from '../../../../../server/paths/apply'
-import { pageIsActiveInNavigation, pageHasLinkToGuidance } from '../utils'
+import { pageIsActiveInNavigation } from '../utils'
 import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 
 export default class BrainInjuryPage extends ApplyPage {
@@ -14,7 +14,6 @@ export default class BrainInjuryPage extends ApplyPage {
     )
 
     pageIsActiveInNavigation('Brain injury')
-    pageHasLinkToGuidance()
     this.pageHasBrainInjuryGuidance()
   }
 

--- a/integration_tests/pages/apply/risks_and_needs/health-needs/communicationAndLanguagePage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/health-needs/communicationAndLanguagePage.ts
@@ -1,7 +1,7 @@
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import ApplyPage from '../../applyPage'
 import paths from '../../../../../server/paths/apply'
-import { pageIsActiveInNavigation, pageHasLinkToGuidance } from '../utils'
+import { pageIsActiveInNavigation } from '../utils'
 import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 
 export default class CommunicationAndLanguagePage extends ApplyPage {
@@ -12,7 +12,6 @@ export default class CommunicationAndLanguagePage extends ApplyPage {
       'health-needs',
       'communication-and-language',
     )
-    pageHasLinkToGuidance()
     pageIsActiveInNavigation('Communication and language')
   }
 

--- a/integration_tests/pages/apply/risks_and_needs/health-needs/independentLivingPage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/health-needs/independentLivingPage.ts
@@ -1,0 +1,27 @@
+import { Cas2v2Application as Application } from '@approved-premises/api'
+import ApplyPage from '../../applyPage'
+import paths from '../../../../../server/paths/apply'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+
+export default class IndependentLivingPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `Can ${nameOrPlaceholderCopy(application.person)} live independently and in shared accommodation?`,
+      application,
+      'health-needs',
+      'independent-living',
+    )
+  }
+
+  static visit(application: Application): IndependentLivingPage {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'health-needs',
+        page: 'independent-living',
+      }),
+    )
+
+    return new IndependentLivingPage(application)
+  }
+}

--- a/integration_tests/pages/apply/risks_and_needs/health-needs/learningDifficultiesPage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/health-needs/learningDifficultiesPage.ts
@@ -1,7 +1,7 @@
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import ApplyPage from '../../applyPage'
 import paths from '../../../../../server/paths/apply'
-import { pageIsActiveInNavigation, pageHasLinkToGuidance } from '../utils'
+import { pageIsActiveInNavigation } from '../utils'
 import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 
 export default class LearningDifficultiesPage extends ApplyPage {
@@ -14,7 +14,6 @@ export default class LearningDifficultiesPage extends ApplyPage {
     )
 
     pageIsActiveInNavigation('Learning difficulties')
-    pageHasLinkToGuidance()
     this.pageHasNeurodiversityGuidance()
   }
 

--- a/integration_tests/pages/apply/risks_and_needs/health-needs/liaisonAndDiversionPage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/health-needs/liaisonAndDiversionPage.ts
@@ -1,0 +1,31 @@
+import { Cas2v2Application as Application } from '@approved-premises/api'
+import ApplyPage from '../../applyPage'
+import paths from '../../../../../server/paths/apply'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
+
+export default class LiaisonAndDiversionPage extends ApplyPage {
+  constructor(private readonly application: Application) {
+    super(
+      `Liaison and Diversion Assessment for ${nameOrPlaceholderCopy(application.person)}`,
+      application,
+      'health-needs',
+      'liaison-and-diversion',
+    )
+  }
+
+  static visit(application: Application): LiaisonAndDiversionPage {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'health-needs',
+        page: 'liaison-and-diversion',
+      }),
+    )
+
+    return new LiaisonAndDiversionPage(application)
+  }
+
+  completeForm(): void {
+    this.checkRadioByNameAndValue('liaisonAndDiversionAssessment', 'yes')
+  }
+}

--- a/integration_tests/pages/apply/risks_and_needs/health-needs/mentalHealthPage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/health-needs/mentalHealthPage.ts
@@ -1,7 +1,7 @@
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import ApplyPage from '../../applyPage'
 import paths from '../../../../../server/paths/apply'
-import { pageIsActiveInNavigation, pageHasLinkToGuidance, fieldIsOptional } from '../utils'
+import { pageIsActiveInNavigation, fieldIsOptional } from '../utils'
 import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 
 export default class MentalHealthPage extends ApplyPage {
@@ -12,7 +12,6 @@ export default class MentalHealthPage extends ApplyPage {
       'health-needs',
       'mental-health',
     )
-    pageHasLinkToGuidance()
     pageIsActiveInNavigation('Mental health')
   }
 

--- a/integration_tests/pages/apply/risks_and_needs/health-needs/otherHealthPage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/health-needs/otherHealthPage.ts
@@ -1,7 +1,7 @@
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import ApplyPage from '../../applyPage'
 import paths from '../../../../../server/paths/apply'
-import { pageIsActiveInNavigation, pageHasLinkToGuidance } from '../utils'
+import { pageIsActiveInNavigation } from '../utils'
 import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 
 export default class OtherHealthPage extends ApplyPage {
@@ -12,7 +12,6 @@ export default class OtherHealthPage extends ApplyPage {
       'health-needs',
       'other-health',
     )
-    pageHasLinkToGuidance()
     pageIsActiveInNavigation('Other health')
   }
 

--- a/integration_tests/pages/apply/risks_and_needs/health-needs/physicalHealthPage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/health-needs/physicalHealthPage.ts
@@ -1,7 +1,7 @@
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import ApplyPage from '../../applyPage'
 import paths from '../../../../../server/paths/apply'
-import { pageIsActiveInNavigation, pageHasLinkToGuidance } from '../utils'
+import { pageIsActiveInNavigation } from '../utils'
 import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 
 export default class PhysicalHealthPage extends ApplyPage {
@@ -12,7 +12,6 @@ export default class PhysicalHealthPage extends ApplyPage {
       'health-needs',
       'physical-health',
     )
-    pageHasLinkToGuidance()
     pageIsActiveInNavigation('Physical health')
   }
 

--- a/integration_tests/pages/apply/risks_and_needs/health-needs/substanceMisusePage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/health-needs/substanceMisusePage.ts
@@ -1,7 +1,7 @@
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import ApplyPage from '../../applyPage'
 import paths from '../../../../../server/paths/apply'
-import { pageIsActiveInNavigation, pageHasLinkToGuidance } from '../utils'
+import { pageIsActiveInNavigation } from '../utils'
 import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 
 export default class SubstanceMisusePage extends ApplyPage {
@@ -12,7 +12,6 @@ export default class SubstanceMisusePage extends ApplyPage {
       'health-needs',
       'substance-misuse',
     )
-    pageHasLinkToGuidance()
     pageIsActiveInNavigation('Substance misuse')
   }
 

--- a/integration_tests/pages/apply/risks_and_needs/utils.ts
+++ b/integration_tests/pages/apply/risks_and_needs/utils.ts
@@ -2,13 +2,6 @@ export const pageIsActiveInNavigation = (linkText: string): void => {
   cy.get('.moj-side-navigation__item--active a').contains(linkText)
 }
 
-export const pageHasLinkToGuidance = (): void => {
-  cy.get('a')
-    .contains('Who to contact for health care information')
-    .should('have.attr', 'href')
-    .and('match', new RegExp(Cypress._.escapeRegExp('tasks/health-needs/pages/guidance')))
-}
-
 export const fieldIsOptional = (labelId: string): void => {
   cy.get(`label[for="${labelId}"]`).contains('(optional)')
 }

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_information.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/health_needs_information.cy.ts
@@ -1,7 +1,7 @@
-//  Feature: Referrer completes 'Health needs: guidance' page
-//    So that I can complete the first page of the "Health needs" task
+//  Feature: Referrer completes 'Health needs information' page
+//    So that I can complete the "Health needs" task
 //    As a referrer
-//    I want to confirm that I've understood the guidance on that page
+//    I want to confirm that I've understood the information on that page
 //
 //  Scenario: Follows link from task list
 //    Given there is a section with a task

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/independent_living.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/independent_living.cy.ts
@@ -1,27 +1,27 @@
-//  Feature: Referrer completes 'Health needs information' page
+//  Feature: Referrer completes 'Independent living' page
 //    So that I can complete the "Health needs" task
 //    As a referrer
-//    I want to confirm that I've understood the information on that page
+//    I want to complete the independent living page
 //
 //  Scenario: Follows link from task list
 //    Given there is a section with a task
 //    And an application exists
 //    And I am logged in
 //
-//  Scenario: view health needs information page
-//    When I visit the health needs information page
-//    Then I see the health needs information page
+//  Scenario: view Independent living page
+//    When I visit the Independent living page
+//    Then I see the Independent living page
 //
 //  Scenario: continues to next page in "health needs" task
 //    When I continue to the next task/page
 //    Then I should be on the substance misuse page
 
-import SubstanceMisusePage from '../../../../pages/apply/risks_and_needs/health-needs/substanceMisusePage'
 import Page from '../../../../pages/page'
 import HealthNeedsInformationPage from '../../../../pages/apply/risks_and_needs/health-needs/healthNeedsInformationPage'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import IndependentLivingPage from '../../../../pages/apply/risks_and_needs/health-needs/independentLivingPage'
 
-context('Visit health needs information page', () => {
+context('Visit Independent living page', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
 
   beforeEach(function test() {
@@ -51,22 +51,22 @@ context('Visit health needs information page', () => {
     cy.signIn()
   })
 
-  //  Scenario: view health needs information page
+  //  Scenario: view Independent living page
   it('shows the page', function test() {
-    //  When I visit the health needs information page
-    HealthNeedsInformationPage.visit(this.application)
+    //  When I visit the Independent living page
+    IndependentLivingPage.visit(this.application)
 
-    //  Then I see the health needs information page
-    Page.verifyOnPage(HealthNeedsInformationPage, this.application)
+    //  Then I see the Independent living page
+    Page.verifyOnPage(IndependentLivingPage, this.application)
   })
 
   //  Scenario: continues to next page in "health needs" task
   it('continues to the next page', function test() {
     //  When I continue to the next task/page
-    const page = HealthNeedsInformationPage.visit(this.application)
-    page.clickContinue()
+    const page = IndependentLivingPage.visit(this.application)
+    page.clickSubmit()
 
-    //  Then I should be on the substance misuse page
-    Page.verifyOnPage(SubstanceMisusePage, this.application)
+    //  Then I should be on the health needs information page
+    Page.verifyOnPage(HealthNeedsInformationPage, this.application)
   })
 })

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/liaison_and_diversion.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/liaison_and_diversion.cy.ts
@@ -1,0 +1,78 @@
+//  Feature: Referrer completes 'Liaison and diversion assessment' page
+//    So that I can complete the "Health needs" task
+//    As a referrer
+//    I want to complete the Liaison and diversion assessment page
+//
+//  Scenario: Follows link from task list
+//    Given there is a section with a task
+//    And an application exists
+//    And I am logged in
+//
+//  Scenario: view Liaison and diversion assessment page
+//    Given I am on the task list page
+//    When I follow the link to the health needs task
+//    Then I see the Liaison and diversion assessment page
+//
+//  Scenario: continues to next page in "health needs" task
+//    When I continue to the next task/page
+//    Then I should be on the independent living page
+
+import Page from '../../../../pages/page'
+import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import LiaisonAndDiversionPage from '../../../../pages/apply/risks_and_needs/health-needs/liaisonAndDiversionPage'
+import TaskListPage from '../../../../pages/apply/taskListPage'
+import IndependentLivingPage from '../../../../pages/apply/risks_and_needs/health-needs/independentLivingPage'
+
+context('Visit Liaison and diversion assessment page', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(function test() {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    cy.fixture('applicationData.json').then(applicationData => {
+      applicationData['health-needs'] = {}
+      const application = applicationFactory.build({
+        id: 'abc123',
+        person,
+        data: applicationData,
+      })
+      cy.wrap(application).as('application')
+    })
+  })
+
+  beforeEach(function test() {
+    // And an application exists
+    // -------------------------
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplicationUpdate', { application: this.application })
+
+    // Given I am logged in
+    //---------------------
+    cy.signIn()
+  })
+
+  //  Scenario: view Liaison and diversion assessment page
+  it('shows the page', function test() {
+    //  Given I am on the task list page
+    const page = TaskListPage.visit(this.application)
+
+    //  When I follow the link to the health needs task
+    page.clickLink('Add health needs')
+
+    //  Then I see the Liaison and diversion assessment page
+    Page.verifyOnPage(LiaisonAndDiversionPage, this.application)
+  })
+
+  //  Scenario: continues to next page in "health needs" task
+  it('continues to the next page', function test() {
+    //  When I continue to the next task/page
+    const page = LiaisonAndDiversionPage.visit(this.application)
+    page.completeForm()
+    page.clickSubmit()
+
+    //  Then I should be on the independent living page
+    Page.verifyOnPage(IndependentLivingPage, this.application)
+  })
+})

--- a/server/form-pages/apply/risks-and-needs/health-needs/liaisonAndDiversion.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/liaisonAndDiversion.test.ts
@@ -9,7 +9,7 @@ describe('LiaisonAndDiversion', () => {
     it('personalises the page title', () => {
       const page = new LiaisonAndDiversion({}, application)
 
-      expect(page.title).toEqual('Liaison & Diversion Assessment for Roger Smith')
+      expect(page.title).toEqual('Liaison and Diversion Assessment for Roger Smith')
     })
   })
 
@@ -33,7 +33,7 @@ describe('LiaisonAndDiversion', () => {
       it('includes a validation error for _liaisonAndDiversionAssessment_', () => {
         expect(page.errors()).toHaveProperty(
           'liaisonAndDiversionAssessment',
-          'Confirm whether a Liaison & Diversion Assessment has been requested',
+          "Select if a Liaison and Diversion Assessment has been carried out, or select 'I don't know'",
         )
       })
     })

--- a/server/form-pages/apply/risks-and-needs/health-needs/liaisonAndDiversion.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/liaisonAndDiversion.ts
@@ -14,11 +14,11 @@ type LiaisonAndDiversionBody = {
   bodyProperties: ['liaisonAndDiversionAssessment'],
 })
 export default class LiaisonAndDiversion implements TaskListPage {
-  documentTitle = 'Liaison & Diversion Assessment for the person'
+  documentTitle = 'Liaison and Diversion Assessment for the person'
 
   personName = nameOrPlaceholderCopy(this.application.person)
 
-  title = `Liaison & Diversion Assessment for ${this.personName}`
+  title = `Liaison and Diversion Assessment for ${this.personName}`
 
   questions = getQuestions(this.personName)['health-needs']['liaison-and-diversion']
 
@@ -43,7 +43,8 @@ export default class LiaisonAndDiversion implements TaskListPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.liaisonAndDiversionAssessment) {
-      errors.liaisonAndDiversionAssessment = `Confirm whether a Liaison & Diversion Assessment has been requested`
+      errors.liaisonAndDiversionAssessment =
+        "Select if a Liaison and Diversion Assessment has been carried out, or select 'I don't know'"
     }
 
     return errors

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -646,8 +646,9 @@ export const getQuestions = (name: string) => {
       },
       'liaison-and-diversion': {
         liaisonAndDiversionAssessment: {
-          question: `Does ${name} have a Liaison & Diversion Assessment?`,
-          answers: yesOrNo,
+          question: `Has a Liaison and Diversion Assessment been carried out for ${name}?`,
+          hint: 'This may have been carried out by the police or in court if the applicant has any mental health issues, learning disabilities, substance misuse problems, or other vulnerabilities.',
+          answers: yesNoOrIDontKnow,
         },
       },
       'other-health': {

--- a/server/views/applications/pages/health-needs/_health-needs-screen.njk
+++ b/server/views/applications/pages/health-needs/_health-needs-screen.njk
@@ -8,13 +8,6 @@
   <div class="govuk-grid-row" id="{{ pageName }}">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ page.title }}</h1>
-
-      <a
-        href="{{paths.applications.pages.show({ id: applicationId, task: 'health-needs', page: 'guidance' })}}"
-        class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19"
-        >
-        Who to contact for health care information
-      </a>
     </div>
   </div>
 

--- a/server/views/applications/pages/health-needs/liaison-and-diversion.njk
+++ b/server/views/applications/pages/health-needs/liaison-and-diversion.njk
@@ -13,6 +13,7 @@
             classes: "govuk-fieldset__legend--m"
           }
         },
+        hint: { text: page.questions.liaisonAndDiversionAssessment.hint },
         items: [
         {
           value: "yes",
@@ -21,6 +22,13 @@
         {
           value: "no",
           text: "No"
+        },
+        {
+          divider: 'or'
+        },
+        {
+          value: "dontKnow",
+          text: "I don't know"
         }
       ]
       },


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-280

# Changes in this PR

- Updates L&D page title, hint text and answers
- Adds missing integration tests for health needs information page and independent living page

## Screenshots of UI changes

### Before

![Screenshot 2025-03-05 at 10 28 34](https://github.com/user-attachments/assets/fc69bf79-eb7f-4f72-95d9-3ec4e56ad0d7)

### After

![Screenshot 2025-03-05 at 10 25 19](https://github.com/user-attachments/assets/b6652429-7047-43d6-9b6d-dd3102d03cd6)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
