### PR TITLE
CBA-277: change content on communication and language needs page

### DIFF
--- a/e2e-tests/steps/risksAndNeedsSection.ts
+++ b/e2e-tests/steps/risksAndNeedsSection.ts
@@ -74,8 +74,8 @@ async function completeMentalHealthPage(page: Page, name: string) {
 async function completeCommunicationAndLanguagePage(page: Page, name: string) {
   const communicationPage = await ApplyPage.initialize(page, `Communication and language needs for ${name}`)
 
+  await communicationPage.checkRadioInGroup('impairments', 'No')
   await communicationPage.checkRadioInGroup('interpreter', 'No')
-  await communicationPage.checkRadioInGroup('need any support', 'No')
 
   await communicationPage.clickSave()
 }

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -177,10 +177,10 @@
       "cantManageMedicationNotes": ""
     },
     "communication-and-language": {
+      "hasImpairments": "no",
+      "impairmentsDetail": "",
       "requiresInterpreter": "no",
       "interpretationDetail": "",
-      "hasSupportNeeds": "no",
-      "supportDetail": "",
       "oldQuestion": "this answer should not appear"
     },
     "learning-difficulties": {

--- a/integration_tests/pages/apply/risks_and_needs/health-needs/communicationAndLanguagePage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/health-needs/communicationAndLanguagePage.ts
@@ -30,8 +30,8 @@ export default class CommunicationAndLanguagePage extends ApplyPage {
     this.getTextInputByIdAndEnterDetails('interpretationDetail', 'Welsh')
   }
 
-  describeSupportNeeded = (): void => {
-    this.checkRadioByNameAndValue('hasSupportNeeds', 'yes')
-    this.getTextInputByIdAndEnterDetails('supportDetail', 'Struggles with written comprehension')
+  describeImpairments = (): void => {
+    this.checkRadioByNameAndValue('hasImpairments', 'yes')
+    this.getTextInputByIdAndEnterDetails('impairmentsDetail', 'Struggles with written comprehension')
   }
 }

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/communication_and_language.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/communication_and_language.cy.ts
@@ -17,7 +17,7 @@
 //    Then I see the "learning difficulties" page
 
 import Page from '../../../../pages/page'
-import CommunicationAndLanguage from '../../../../pages/apply/risks_and_needs/health-needs/communicationAndLanguagePage'
+import CommunicationAndLanguagePage from '../../../../pages/apply/risks_and_needs/health-needs/communicationAndLanguagePage'
 import LearningDifficultiesPage from '../../../../pages/apply/risks_and_needs/health-needs/learningDifficultiesPage'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 
@@ -52,13 +52,13 @@ context('Visit "communication and language" page', () => {
 
     // And I am on the communication and language page
     // --------------------------------
-    CommunicationAndLanguage.visit(this.application)
+    CommunicationAndLanguagePage.visit(this.application)
   })
 
   //  Scenario: view communication and language questions
   //    Then I see the "communication and language" page
   it('presents communication and language page', function test() {
-    Page.verifyOnPage(CommunicationAndLanguage, this.application)
+    Page.verifyOnPage(CommunicationAndLanguagePage, this.application)
   })
 
   //  Scenario: complete page and navigate to next page in health needs task
@@ -66,12 +66,11 @@ context('Visit "communication and language" page', () => {
   //    And I continue to the next task / page
   //    Then I see the "learning difficulties" page
   it('navigates to the next page (learning difficulties)', function test() {
-    CommunicationAndLanguage.visit(this.application)
-    const page = new CommunicationAndLanguage(this.application)
+    CommunicationAndLanguagePage.visit(this.application)
+    const page = new CommunicationAndLanguagePage(this.application)
 
+    page.describeImpairments()
     page.specifyInterpretationNeeds()
-    page.describeSupportNeeded()
-
     page.clickSubmit()
 
     Page.verifyOnPage(LearningDifficultiesPage, this.application)

--- a/server/form-pages/apply/risks-and-needs/health-needs/communicationAndLanguage.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/communicationAndLanguage.test.ts
@@ -5,36 +5,6 @@ import CommunicationAndLanguage, { CommunicationAndLanguageBody } from './commun
 describe('CommunicationAndLanguage', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
 
-  describe('title', () => {
-    it('personalises the page title', () => {
-      const page = new CommunicationAndLanguage({}, application)
-
-      expect(page.title).toEqual('Communication and language needs for Roger Smith')
-    })
-  })
-
-  describe('questions', () => {
-    const page = new CommunicationAndLanguage({}, application)
-
-    describe('requiresInterpreter', () => {
-      it('has a question', () => {
-        expect(page.questions.requiresInterpreter.question).toBeDefined()
-      })
-      it('has a follow-up question', () => {
-        expect(page.questions.interpretationDetail.question).toBeDefined()
-      })
-    })
-
-    describe('hasSupportNeeds', () => {
-      it('has a question', () => {
-        expect(page.questions.hasSupportNeeds.question).toBeDefined()
-      })
-      it('has a follow-up question', () => {
-        expect(page.questions.supportDetail.question).toBeDefined()
-      })
-    })
-  })
-
   itShouldHaveNextValue(new CommunicationAndLanguage({}, application), 'learning-difficulties')
   itShouldHavePreviousValue(new CommunicationAndLanguage({}, application), 'mental-health')
 
@@ -42,12 +12,28 @@ describe('CommunicationAndLanguage', () => {
     describe('when top-level questions are unanswered', () => {
       const page = new CommunicationAndLanguage({}, application)
 
-      it('includes a validation error for _requiresInterpreter_', () => {
-        expect(page.errors()).toHaveProperty('requiresInterpreter', 'Confirm whether they need an interpreter')
+      it('includes a validation error for _hasImpairments_', () => {
+        expect(page.errors()).toHaveProperty(
+          'hasImpairments',
+          `Select if they have any literacy, visual or hearing impairments, or select 'I do not know'`,
+        )
       })
 
-      it('includes a validation error for _hasSupportNeeds_', () => {
-        expect(page.errors()).toHaveProperty('hasSupportNeeds', 'Confirm they they need support')
+      it('includes a validation error for _requiresInterpreter_', () => {
+        expect(page.errors()).toHaveProperty(
+          'requiresInterpreter',
+          `Select if they need an interpreter, or select 'I do not know'`,
+        )
+      })
+    })
+
+    describe('when _hasImpairments_ is YES', () => {
+      const page = new CommunicationAndLanguage({ hasImpairments: 'yes' }, application)
+
+      describe('and _impairmentsDetail_ is UNANSWERED', () => {
+        it('includes a validation error for _impairmentsDetail_', () => {
+          expect(page.errors()).toHaveProperty('impairmentsDetail', 'Enter details of their needs')
+        })
       })
     })
 
@@ -58,20 +44,7 @@ describe('CommunicationAndLanguage', () => {
         it('includes a validation error for _interpretationDetail_', () => {
           expect(page.errors()).toHaveProperty(
             'interpretationDetail',
-            'Specify the language the interpreter is needed for',
-          )
-        })
-      })
-    })
-
-    describe('when _hasSupportNeeds_ is YES', () => {
-      const page = new CommunicationAndLanguage({ hasSupportNeeds: 'yes' }, application)
-
-      describe('and _supportDetail_ is UNANSWERED', () => {
-        it('includes a validation error for _supportDetail_', () => {
-          expect(page.errors()).toHaveProperty(
-            'supportDetail',
-            'Describe the support needed to see, hear, speak or understand',
+            'Enter the language they need an interpreter for',
           )
         })
       })
@@ -79,6 +52,21 @@ describe('CommunicationAndLanguage', () => {
   })
 
   describe('onSave', () => {
+    it('removes impairment data when the question is set to "no"', () => {
+      const body: Partial<CommunicationAndLanguageBody> = {
+        hasImpairments: 'no',
+        impairmentsDetail: 'Impairment detail',
+      }
+
+      const page = new CommunicationAndLanguage(body, application)
+
+      page.onSave()
+
+      expect(page.body).toEqual({
+        hasImpairments: 'no',
+      })
+    })
+
     it('removes interpreter data when the question is set to "no"', () => {
       const body: Partial<CommunicationAndLanguageBody> = {
         requiresInterpreter: 'no',
@@ -91,21 +79,6 @@ describe('CommunicationAndLanguage', () => {
 
       expect(page.body).toEqual({
         requiresInterpreter: 'no',
-      })
-    })
-
-    it('removes support needs data when the question is set to "no"', () => {
-      const body: Partial<CommunicationAndLanguageBody> = {
-        hasSupportNeeds: 'no',
-        supportDetail: 'Support detail',
-      }
-
-      const page = new CommunicationAndLanguage(body, application)
-
-      page.onSave()
-
-      expect(page.body).toEqual({
-        hasSupportNeeds: 'no',
       })
     })
   })

--- a/server/form-pages/apply/risks-and-needs/health-needs/communicationAndLanguage.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/communicationAndLanguage.ts
@@ -1,4 +1,4 @@
-import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import type { TaskListErrors, YesNoOrDontKnow, YesOrNo } from '@approved-premises/ui'
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
@@ -6,15 +6,15 @@ import TaskListPage from '../../../taskListPage'
 import { getQuestions } from '../../../utils/questions'
 
 export type CommunicationAndLanguageBody = {
+  hasImpairments: YesNoOrDontKnow
+  impairmentsDetail: string
   requiresInterpreter: YesOrNo
   interpretationDetail: string
-  hasSupportNeeds: YesOrNo
-  supportDetail: string
 }
 
 @Page({
   name: 'communication-and-language',
-  bodyProperties: ['requiresInterpreter', 'interpretationDetail', 'hasSupportNeeds', 'supportDetail'],
+  bodyProperties: ['hasImpairments', 'impairmentsDetail', 'requiresInterpreter', 'interpretationDetail'],
 })
 export default class CommunicationAndLanguage implements TaskListPage {
   documentTitle = 'Communication and language needs for the person'
@@ -45,30 +45,30 @@ export default class CommunicationAndLanguage implements TaskListPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
-    if (!this.body.requiresInterpreter) {
-      errors.requiresInterpreter = `Confirm whether they need an interpreter`
+    if (!this.body.hasImpairments) {
+      errors.hasImpairments = `Select if they have any literacy, visual or hearing impairments, or select 'I do not know'`
     }
-    if (this.body.requiresInterpreter === 'yes' && !this.body.interpretationDetail) {
-      errors.interpretationDetail = 'Specify the language the interpreter is needed for'
+    if (this.body.hasImpairments === 'yes' && !this.body.impairmentsDetail) {
+      errors.impairmentsDetail = 'Enter details of their needs'
     }
 
-    if (!this.body.hasSupportNeeds) {
-      errors.hasSupportNeeds = `Confirm they they need support`
+    if (!this.body.requiresInterpreter) {
+      errors.requiresInterpreter = `Select if they need an interpreter, or select 'I do not know'`
     }
-    if (this.body.hasSupportNeeds === 'yes' && !this.body.supportDetail) {
-      errors.supportDetail = 'Describe the support needed to see, hear, speak or understand'
+    if (this.body.requiresInterpreter === 'yes' && !this.body.interpretationDetail) {
+      errors.interpretationDetail = 'Enter the language they need an interpreter for'
     }
 
     return errors
   }
 
   onSave(): void {
-    if (this.body.requiresInterpreter !== 'yes') {
-      delete this.body.interpretationDetail
+    if (this.body.hasImpairments !== 'yes') {
+      delete this.body.impairmentsDetail
     }
 
-    if (this.body.hasSupportNeeds !== 'yes') {
-      delete this.body.supportDetail
+    if (this.body.requiresInterpreter !== 'yes') {
+      delete this.body.interpretationDetail
     }
   }
 }

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -598,13 +598,15 @@ export const getQuestions = (name: string) => {
         },
       },
       'communication-and-language': {
-        requiresInterpreter: { question: 'Do they need an interpreter?', answers: yesOrNo },
-        interpretationDetail: { question: 'What language do they need an interpreter for?' },
-        hasSupportNeeds: {
-          question: 'Do they need any support to see, hear, speak, or understand?',
-          answers: yesOrNo,
+        hasImpairments: {
+          question: 'Do they have any literacy, visual or hearing impairments?',
+          answers: yesNoOrIDontKnow,
         },
-        supportDetail: { question: 'Please describe their support needs.' },
+        impairmentsDetail: {
+          question: 'Enter details of their needs, including any support they have already or will need',
+        },
+        requiresInterpreter: { question: 'Do they need an interpreter?', answers: yesNoOrIDontKnow },
+        interpretationDetail: { question: 'What language do they need an interpreter for?' },
       },
       'learning-difficulties': {
         hasLearningNeeds: {

--- a/server/views/applications/pages/health-needs/communication-and-language.njk
+++ b/server/views/applications/pages/health-needs/communication-and-language.njk
@@ -3,6 +3,21 @@
 
 {% block questions %}
 
+  {% set impairmentsFollowUp %}
+  {{
+      formPageTextArea(
+        {
+          fieldName: 'impairmentsDetail',
+          label: {
+            text: page.questions.impairmentsDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset %}
+
   {% set interpretationFollowUp %}
   {{
       formPageInput(
@@ -18,20 +33,40 @@
     }}
   {% endset %}
 
-  {% set supportFollowUp %}
-  {{
-      formPageTextArea(
-        {
-          fieldName: 'supportDetail',
-          label: {
-            text: page.questions.supportDetail.question,
-            classes: "govuk-label--s"
+   {{
+    formPageRadios(
+      {
+        fieldName: "hasImpairments",
+        fieldset: {
+          legend: {
+            text: page.questions.hasImpairments.question,
+            classes: "govuk-fieldset__legend--m"
           }
         },
-        fetchContext()
-      )
-    }}
-  {% endset %}
+        items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: impairmentsFollowUp
+          }
+        },
+        {
+          value: "no",
+          text: "No"
+        },
+        {
+          divider: 'or'
+        },
+        {
+          value: "dontKnow",
+          text: "I don't know"
+        }
+      ]
+      },
+      fetchContext()
+    )
+  }}
 
   {{
     formPageRadios(
@@ -54,33 +89,13 @@
         {
           value: "no",
           text: "No"
-        }
-      ]
-      },
-      fetchContext()
-    )
-  }}
-  {{
-    formPageRadios(
-      {
-        fieldName: "hasSupportNeeds",
-        fieldset: {
-          legend: {
-            text: page.questions.hasSupportNeeds.question,
-            classes: "govuk-fieldset__legend--m"
-          }
-        },
-        items: [
-        {
-          value: "yes",
-          text: "Yes",
-          conditional: {
-            html: supportFollowUp
-          }
         },
         {
-          value: "no",
-          text: "No"
+          divider: 'or'
+        },
+        {
+          value: "dontKnow",
+          text: "I do not know"
         }
       ]
       },


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-277

# Changes in this PR

Updates communication and language needs page questions.

## Screenshots of UI changes

### Before

<img width="1127" alt="Screenshot 2025-03-06 at 10 13 03" src="https://github.com/user-attachments/assets/871cde9b-953f-4f0b-a2fb-4974503c854e" />

### After

<img width="1123" alt="Screenshot 2025-03-06 at 10 12 48" src="https://github.com/user-attachments/assets/8a12fefe-72f8-4281-8c76-9419803364e5" />

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
