### PR TITLE
CBA-285: change content on brain injury details for applicant page

### DIFF
--- a/e2e-tests/steps/risksAndNeedsSection.ts
+++ b/e2e-tests/steps/risksAndNeedsSection.ts
@@ -95,9 +95,10 @@ async function completeBrainInjuryPage(page: Page, name: string) {
   const brainInjuryPage = await ApplyPage.initialize(page, `Brain injury needs for ${name}`)
 
   await brainInjuryPage.checkRadioInGroup('brain injury?', 'No')
+  await brainInjuryPage.checkRadioInGroup('any support', 'No')
+  await brainInjuryPage.checkRadioInGroup('treatment', 'No')
   await brainInjuryPage.checkRadioInGroup('vulnerable', 'No')
   await brainInjuryPage.checkRadioInGroup('difficulties interacting', 'No')
-  await brainInjuryPage.checkRadioInGroup('additional support', 'No')
 
   await brainInjuryPage.clickSave()
 }

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -196,12 +196,14 @@
     "brain-injury": {
       "hasBrainInjury": "no",
       "injuryDetail": "",
+      "supportNeeded": "no",
+      "supportDetail": "",
+      "receivingTreatment": "no",
+      "treatmentDetail": "",
       "isVulnerable": "no",
       "vulnerabilityDetail": "",
       "hasDifficultyInteracting": "no",
-      "interactionDetail": "",
-      "requiresAdditionalSupport": "no",
-      "addSupportDetail": ""
+      "interactionDetail": ""
     },
     "other-health": {
       "hasLongTermHealthCondition": "no",

--- a/integration_tests/pages/apply/risks_and_needs/health-needs/brainInjuryPage.ts
+++ b/integration_tests/pages/apply/risks_and_needs/health-needs/brainInjuryPage.ts
@@ -28,12 +28,22 @@ export default class BrainInjuryPage extends ApplyPage {
   }
 
   pageHasBrainInjuryGuidance = (): void => {
-    cy.get('.guidance').contains('This could be as a result of accident')
+    cy.get('p').contains('This could be as a result of accident')
   }
 
   describeInjuryAndNeeds = (): void => {
     this.checkRadioByNameAndValue('hasBrainInjury', 'yes')
     this.getTextInputByIdAndEnterDetails('injuryDetail', 'Has frontal lobe damange')
+  }
+
+  describeSupportNeeded = (): void => {
+    this.checkRadioByNameAndValue('supportNeeded', 'yes')
+    this.getTextInputByIdAndEnterDetails('supportDetail', 'Requires regular support')
+  }
+
+  describeTreatment = (): void => {
+    this.checkRadioByNameAndValue('receivingTreatment', 'yes')
+    this.getTextInputByIdAndEnterDetails('treatmentDetail', 'Lots of treatment')
   }
 
   describeVulnerability = (): void => {
@@ -44,10 +54,5 @@ export default class BrainInjuryPage extends ApplyPage {
   describeDifficultiesInteracting = (): void => {
     this.checkRadioByNameAndValue('hasDifficultyInteracting', 'yes')
     this.getTextInputByIdAndEnterDetails('interactionDetail', 'Can misunderstand situations')
-  }
-
-  describeAdditionalSupportNeeded = (): void => {
-    this.checkRadioByNameAndValue('requiresAdditionalSupport', 'yes')
-    this.getTextInputByIdAndEnterDetails('addSupportDetail', 'Requires regular support')
   }
 }

--- a/integration_tests/tests/apply/risks_and_needs/health-needs/brain_injury.cy.ts
+++ b/integration_tests/tests/apply/risks_and_needs/health-needs/brain_injury.cy.ts
@@ -70,9 +70,10 @@ context('Visit "brain injury" page', () => {
     const page = new BrainInjuryPage(this.application)
 
     page.describeInjuryAndNeeds()
+    page.describeSupportNeeded()
+    page.describeTreatment()
     page.describeVulnerability()
     page.describeDifficultiesInteracting()
-    page.describeAdditionalSupportNeeded()
 
     page.clickSubmit()
 

--- a/server/form-pages/apply/risks-and-needs/health-needs/brainInjury.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/brainInjury.test.ts
@@ -6,185 +6,177 @@ describe('BrainInjury', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
 
   describe('title', () => {
-    it('personalises the page title', () => {
-      const page = new BrainInjury({}, application)
+    itShouldHaveNextValue(new BrainInjury({}, application), 'other-health')
+    itShouldHavePreviousValue(new BrainInjury({}, application), 'learning-difficulties')
 
-      expect(page.title).toEqual('Brain injury needs for Roger Smith')
-    })
-  })
+    describe('errors', () => {
+      describe('when top-level questions are unanswered', () => {
+        const page = new BrainInjury({}, application)
 
-  describe('questions', () => {
-    const page = new BrainInjury({}, application)
-
-    describe('hasBrainInjury', () => {
-      it('has a question', () => {
-        expect(page.questions.hasBrainInjury.question).toBeDefined()
-      })
-      it('has one follow-up question', () => {
-        expect(page.questions.injuryDetail.question).toBeDefined()
-      })
-    })
-
-    describe('isVulnerable', () => {
-      it('has a question', () => {
-        expect(page.questions.isVulnerable.question).toBeDefined()
-      })
-      it('has one follow-up question', () => {
-        expect(page.questions.vulnerabilityDetail.question).toBeDefined()
-      })
-    })
-
-    describe('hasDifficultyInteracting', () => {
-      it('has a question', () => {
-        expect(page.questions.hasDifficultyInteracting.question).toBeDefined()
-      })
-      it('has one follow-up question', () => {
-        expect(page.questions.interactionDetail.question).toBeDefined()
-      })
-    })
-
-    describe('requiresAdditionalSupport', () => {
-      it('has a question', () => {
-        expect(page.questions.requiresAdditionalSupport.question).toBeDefined()
-      })
-      it('has one follow-up question', () => {
-        expect(page.questions.addSupportDetail.question).toBeDefined()
-      })
-    })
-  })
-
-  itShouldHaveNextValue(new BrainInjury({}, application), 'other-health')
-  itShouldHavePreviousValue(new BrainInjury({}, application), 'learning-difficulties')
-
-  describe('errors', () => {
-    describe('when top-level questions are unanswered', () => {
-      const page = new BrainInjury({}, application)
-
-      it('includes a validation error for _hasBrainInjury_', () => {
-        expect(page.errors()).toHaveProperty('hasBrainInjury', 'Confirm whether they have a brain injury')
-      })
-
-      it('includes a validation error for _isVulnerable_', () => {
-        expect(page.errors()).toHaveProperty('isVulnerable', 'Confirm whether they are vulnerable')
-      })
-
-      it('includes a validation error for _hasDifficultyInteracting_', () => {
-        expect(page.errors()).toHaveProperty(
-          'hasDifficultyInteracting',
-          'Confirm whether they have difficulties interacting',
-        )
-      })
-
-      it('includes a validation error for _requiresAdditionalSupport_', () => {
-        expect(page.errors()).toHaveProperty(
-          'requiresAdditionalSupport',
-          'Confirm whether additional support is required',
-        )
-      })
-    })
-
-    describe('when _hasBrainInjury_ is YES', () => {
-      const page = new BrainInjury({ hasBrainInjury: 'yes' }, application)
-
-      describe('and _injuryDetail_ is UNANSWERED', () => {
-        it('includes a validation error for _injuryDetail_', () => {
-          expect(page.errors()).toHaveProperty('injuryDetail', 'Describe their brain injury and needs')
-        })
-      })
-    })
-
-    describe('when _isVulnerable_ is YES', () => {
-      const page = new BrainInjury({ isVulnerable: 'yes' }, application)
-
-      describe('and _vulnerabilityDetail_ is UNANSWERED', () => {
-        it('includes a validation error for _vulnerabilityDetail_', () => {
-          expect(page.errors()).toHaveProperty('vulnerabilityDetail', 'Describe their level of vulnerability')
-        })
-      })
-    })
-
-    describe('when _hasDifficultyInteracting_ is YES', () => {
-      const page = new BrainInjury({ hasDifficultyInteracting: 'yes' }, application)
-
-      describe('and _interactionDetail_ is UNANSWERED', () => {
-        it('includes a validation error for _interactionDetail_', () => {
+        it('includes a validation error for _hasBrainInjury_', () => {
           expect(page.errors()).toHaveProperty(
-            'interactionDetail',
-            'Describe their difficulties interacting with other people',
+            'hasBrainInjury',
+            `Select if they have a brain injury, or select 'I do not know'`,
+          )
+        })
+
+        it('includes a validation error for _supportNeeded_', () => {
+          expect(page.errors()).toHaveProperty(
+            'supportNeeded',
+            `Select if they need any support, or select 'I do not know'`,
+          )
+        })
+
+        it('includes a validation error for _receivingTreatment_', () => {
+          expect(page.errors()).toHaveProperty(
+            'receivingTreatment',
+            `Select if they receive any treatment or medication, or select 'I do not know'`,
+          )
+        })
+
+        it('includes a validation error for _isVulnerable_', () => {
+          expect(page.errors()).toHaveProperty(
+            'isVulnerable',
+            `Select if they are vulnerable, or select 'I do not know'`,
+          )
+        })
+
+        it('includes a validation error for _hasDifficultyInteracting_', () => {
+          expect(page.errors()).toHaveProperty(
+            'hasDifficultyInteracting',
+            `Select if they have difficulties interacting with other people, or select 'I do not know'`,
           )
         })
       })
-    })
 
-    describe('when _requiresAdditionalSupport_ is YES', () => {
-      const page = new BrainInjury({ requiresAdditionalSupport: 'yes' }, application)
+      describe('when _hasBrainInjury_ is YES', () => {
+        const page = new BrainInjury({ hasBrainInjury: 'yes' }, application)
 
-      describe('and _addSupportDetail_ is UNANSWERED', () => {
-        it('includes a validation error for _addSupportDetail_', () => {
-          expect(page.errors()).toHaveProperty('addSupportDetail', 'Describe the additional support required')
+        describe('and _injuryDetail_ is UNANSWERED', () => {
+          it('includes a validation error for _injuryDetail_', () => {
+            expect(page.errors()).toHaveProperty('injuryDetail', 'Enter details of their brain injury and needs')
+          })
+        })
+      })
+
+      describe('when _supportNeeded_ is YES', () => {
+        const page = new BrainInjury({ supportNeeded: 'yes' }, application)
+
+        describe('and _supportDetail_ is UNANSWERED', () => {
+          it('includes a validation error for _supportDetail_', () => {
+            expect(page.errors()).toHaveProperty('supportDetail', 'Enter the type of support needed')
+          })
+        })
+      })
+
+      describe('when _receivingTreatment_ is YES', () => {
+        const page = new BrainInjury({ receivingTreatment: 'yes' }, application)
+
+        describe('and _treatmentDetail_ is UNANSWERED', () => {
+          it('includes a validation error for _treatmentDetail_', () => {
+            expect(page.errors()).toHaveProperty(
+              'treatmentDetail',
+              'Enter details about their treatment and medication',
+            )
+          })
+        })
+      })
+
+      describe('when _isVulnerable_ is YES', () => {
+        const page = new BrainInjury({ isVulnerable: 'yes' }, application)
+
+        describe('and _vulnerabilityDetail_ is UNANSWERED', () => {
+          it('includes a validation error for _vulnerabilityDetail_', () => {
+            expect(page.errors()).toHaveProperty('vulnerabilityDetail', 'Enter how they are vulnerable')
+          })
+        })
+      })
+
+      describe('when _hasDifficultyInteracting_ is YES', () => {
+        const page = new BrainInjury({ hasDifficultyInteracting: 'yes' }, application)
+
+        describe('and _interactionDetail_ is UNANSWERED', () => {
+          it('includes a validation error for _interactionDetail_', () => {
+            expect(page.errors()).toHaveProperty('interactionDetail', 'Enter the type of difficulties they have')
+          })
         })
       })
     })
-  })
 
-  describe('onSave', () => {
-    it('removes brain injury data when the question is set to "no"', () => {
-      const body: Partial<BrainInjuryBody> = {
-        hasBrainInjury: 'no',
-        injuryDetail: 'Injury detail',
-      }
+    describe('onSave', () => {
+      it('removes brain injury data when the question is set to "no"', () => {
+        const body: Partial<BrainInjuryBody> = {
+          hasBrainInjury: 'no',
+          injuryDetail: 'Injury detail',
+        }
 
-      const page = new BrainInjury(body, application)
+        const page = new BrainInjury(body, application)
 
-      page.onSave()
+        page.onSave()
 
-      expect(page.body).toEqual({
-        hasBrainInjury: 'no',
+        expect(page.body).toEqual({
+          hasBrainInjury: 'no',
+        })
       })
-    })
 
-    it('removes vulnerability data when the question is set to "no"', () => {
-      const body: Partial<BrainInjuryBody> = {
-        isVulnerable: 'no',
-        vulnerabilityDetail: 'Vulnerability detail',
-      }
+      it('removes support data when the question is set to "no"', () => {
+        const body: Partial<BrainInjuryBody> = {
+          supportNeeded: 'no',
+          supportDetail: 'Support detail',
+        }
 
-      const page = new BrainInjury(body, application)
+        const page = new BrainInjury(body, application)
 
-      page.onSave()
+        page.onSave()
 
-      expect(page.body).toEqual({
-        isVulnerable: 'no',
+        expect(page.body).toEqual({
+          supportNeeded: 'no',
+        })
       })
-    })
 
-    it('removes interaction difficulty data when the question is set to "no"', () => {
-      const body: Partial<BrainInjuryBody> = {
-        hasDifficultyInteracting: 'no',
-        interactionDetail: 'Interaction detail',
-      }
+      it('removes treatment data when the question is set to "no"', () => {
+        const body: Partial<BrainInjuryBody> = {
+          receivingTreatment: 'no',
+          treatmentDetail: 'Treatment detail',
+        }
 
-      const page = new BrainInjury(body, application)
+        const page = new BrainInjury(body, application)
 
-      page.onSave()
+        page.onSave()
 
-      expect(page.body).toEqual({
-        hasDifficultyInteracting: 'no',
+        expect(page.body).toEqual({
+          receivingTreatment: 'no',
+        })
       })
-    })
 
-    it('removes additional support data when the question is set to "no"', () => {
-      const body: Partial<BrainInjuryBody> = {
-        requiresAdditionalSupport: 'no',
-        addSupportDetail: 'Additional support detail',
-      }
+      it('removes vulnerability data when the question is set to "no"', () => {
+        const body: Partial<BrainInjuryBody> = {
+          isVulnerable: 'no',
+          vulnerabilityDetail: 'Vulnerability detail',
+        }
 
-      const page = new BrainInjury(body, application)
+        const page = new BrainInjury(body, application)
 
-      page.onSave()
+        page.onSave()
 
-      expect(page.body).toEqual({
-        requiresAdditionalSupport: 'no',
+        expect(page.body).toEqual({
+          isVulnerable: 'no',
+        })
+      })
+
+      it('removes interaction difficulty data when the question is set to "no"', () => {
+        const body: Partial<BrainInjuryBody> = {
+          hasDifficultyInteracting: 'no',
+          interactionDetail: 'Interaction detail',
+        }
+
+        const page = new BrainInjury(body, application)
+
+        page.onSave()
+
+        expect(page.body).toEqual({
+          hasDifficultyInteracting: 'no',
+        })
       })
     })
   })

--- a/server/form-pages/apply/risks-and-needs/health-needs/brainInjury.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/brainInjury.ts
@@ -1,4 +1,4 @@
-import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import type { TaskListErrors, YesNoOrDontKnow } from '@approved-premises/ui'
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
@@ -6,14 +6,16 @@ import TaskListPage from '../../../taskListPage'
 import { getQuestions } from '../../../utils/questions'
 
 export type BrainInjuryBody = {
-  hasBrainInjury: YesOrNo
+  hasBrainInjury: YesNoOrDontKnow
   injuryDetail: string
-  isVulnerable: YesOrNo
+  supportNeeded: YesNoOrDontKnow
+  supportDetail: string
+  receivingTreatment: YesNoOrDontKnow
+  treatmentDetail: string
+  isVulnerable: YesNoOrDontKnow
   vulnerabilityDetail: string
-  hasDifficultyInteracting: YesOrNo
+  hasDifficultyInteracting: YesNoOrDontKnow
   interactionDetail: string
-  requiresAdditionalSupport: YesOrNo
-  addSupportDetail: string
 }
 
 @Page({
@@ -21,12 +23,14 @@ export type BrainInjuryBody = {
   bodyProperties: [
     'hasBrainInjury',
     'injuryDetail',
+    'supportNeeded',
+    'supportDetail',
+    'receivingTreatment',
+    'treatmentDetail',
     'isVulnerable',
     'vulnerabilityDetail',
     'hasDifficultyInteracting',
     'interactionDetail',
-    'requiresAdditionalSupport',
-    'addSupportDetail',
   ],
 })
 export default class BrainInjury implements TaskListPage {
@@ -59,31 +63,38 @@ export default class BrainInjury implements TaskListPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.hasBrainInjury) {
-      errors.hasBrainInjury = `Confirm whether they have a brain injury`
+      errors.hasBrainInjury = `Select if they have a brain injury, or select 'I do not know'`
     }
     if (this.body.hasBrainInjury === 'yes' && !this.body.injuryDetail) {
-      errors.injuryDetail = 'Describe their brain injury and needs'
+      errors.injuryDetail = 'Enter details of their brain injury and needs'
+    }
+
+    if (!this.body.supportNeeded) {
+      errors.supportNeeded = `Select if they need any support, or select 'I do not know'`
+    }
+    if (this.body.supportNeeded === 'yes' && !this.body.supportDetail) {
+      errors.supportDetail = 'Enter the type of support needed'
+    }
+
+    if (!this.body.receivingTreatment) {
+      errors.receivingTreatment = `Select if they receive any treatment or medication, or select 'I do not know'`
+    }
+    if (this.body.receivingTreatment === 'yes' && !this.body.treatmentDetail) {
+      errors.treatmentDetail = 'Enter details about their treatment and medication'
     }
 
     if (!this.body.isVulnerable) {
-      errors.isVulnerable = `Confirm whether they are vulnerable`
+      errors.isVulnerable = `Select if they are vulnerable, or select 'I do not know'`
     }
     if (this.body.isVulnerable === 'yes' && !this.body.vulnerabilityDetail) {
-      errors.vulnerabilityDetail = 'Describe their level of vulnerability'
+      errors.vulnerabilityDetail = 'Enter how they are vulnerable'
     }
 
     if (!this.body.hasDifficultyInteracting) {
-      errors.hasDifficultyInteracting = `Confirm whether they have difficulties interacting`
+      errors.hasDifficultyInteracting = `Select if they have difficulties interacting with other people, or select 'I do not know'`
     }
     if (this.body.hasDifficultyInteracting === 'yes' && !this.body.interactionDetail) {
-      errors.interactionDetail = 'Describe their difficulties interacting with other people'
-    }
-
-    if (!this.body.requiresAdditionalSupport) {
-      errors.requiresAdditionalSupport = `Confirm whether additional support is required`
-    }
-    if (this.body.requiresAdditionalSupport === 'yes' && !this.body.addSupportDetail) {
-      errors.addSupportDetail = 'Describe the additional support required'
+      errors.interactionDetail = 'Enter the type of difficulties they have'
     }
 
     return errors
@@ -94,16 +105,20 @@ export default class BrainInjury implements TaskListPage {
       delete this.body.injuryDetail
     }
 
+    if (this.body.supportNeeded !== 'yes') {
+      delete this.body.supportDetail
+    }
+
+    if (this.body.receivingTreatment !== 'yes') {
+      delete this.body.treatmentDetail
+    }
+
     if (this.body.isVulnerable !== 'yes') {
       delete this.body.vulnerabilityDetail
     }
 
     if (this.body.hasDifficultyInteracting !== 'yes') {
       delete this.body.interactionDetail
-    }
-
-    if (this.body.requiresAdditionalSupport !== 'yes') {
-      delete this.body.addSupportDetail
     }
   }
 }

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -630,21 +630,30 @@ export const getQuestions = (name: string) => {
       'brain-injury': {
         hasBrainInjury: {
           question: 'Do they have a brain injury?',
-          answers: yesOrNo,
+          answers: yesNoOrIDontKnow,
         },
-        injuryDetail: { question: 'Please describe their brain injury and needs.' },
+        injuryDetail: {
+          question: 'Enter details of their brain injury and needs, including if they have a formal diagnosis',
+        },
+        supportNeeded: { question: 'Do they need any support as a result of this?', answers: yesNoOrIDontKnow },
+        supportDetail: {
+          question: 'Enter details of the type of support needed, including any support they have already or will need',
+        },
+        receivingTreatment: { question: 'Do they receive any treatment or medication?', answers: yesNoOrIDontKnow },
+        treatmentDetail: {
+          question: 'Enter details about their treatment and medication',
+          hint: 'For example, if they have it and they can manage it in the community',
+        },
         isVulnerable: {
-          question: 'Are they vulnerable as a result of this injury?',
-          answers: yesOrNo,
+          question: 'Are they vulnerable as a result of this?',
+          answers: yesNoOrIDontKnow,
         },
-        vulnerabilityDetail: { question: 'Please describe their level of vulnerability.' },
+        vulnerabilityDetail: { question: 'Enter details of how they might be vulnerable' },
         hasDifficultyInteracting: {
-          question: 'Do they have difficulties interacting with other people as a result of this injury?',
-          answers: yesOrNo,
+          question: 'Do they have difficulties interacting with other people as a result of their injury?',
+          answers: yesNoOrIDontKnow,
         },
-        interactionDetail: { question: 'Please describe these difficulties.' },
-        requiresAdditionalSupport: { question: 'Is additional support required?', answers: yesOrNo },
-        addSupportDetail: { question: 'Please describe the type of support.' },
+        interactionDetail: { question: 'Enter details of the type of difficulties they have.' },
       },
       'liaison-and-diversion': {
         liaisonAndDiversionAssessment: {

--- a/server/views/applications/pages/health-needs/brain-injury.njk
+++ b/server/views/applications/pages/health-needs/brain-injury.njk
@@ -18,6 +18,37 @@
     }}
   {% endset %}
 
+  {% set supportFollowUp %}
+    {{
+      formPageTextArea(
+        {
+          fieldName: 'supportDetail',
+          label: {
+            text: page.questions.supportDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset %}
+
+  {% set treatmentFollowUp %}
+    {{
+      formPageTextArea(
+        {
+          fieldName: 'treatmentDetail',
+          label: {
+            text: page.questions.treatmentDetail.question,
+            classes: "govuk-label--s"
+          },
+          hint: { text: page.questions.treatmentDetail.hint }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset %}
+
   {% set vulnerabilityFollowUp %}
   {{
       formPageTextArea(
@@ -48,22 +79,7 @@
     }}
   {% endset %}
 
-  {% set addSupportFollowUp %}
-  {{
-      formPageTextArea(
-        {
-          fieldName: 'addSupportDetail',
-          label: {
-            text: page.questions.addSupportDetail.question,
-            classes: "govuk-label--s"
-          }
-        },
-        fetchContext()
-      )
-    }}
-  {% endset %}
-
-  <p class="govuk-body guidance">
+  <p class="govuk-hint">
     This could be as a result of accident, drug and alcohol use or an inherited condition.
   </p>
 
@@ -88,6 +104,83 @@
         {
           value: "no",
           text: "No"
+        },
+        {
+          divider: 'or'
+        },
+        {
+          value: "dontKnow",
+          text: "I do not know"
+        }
+      ]
+      },
+      fetchContext()
+    )
+  }}
+
+    {{
+    formPageRadios(
+      {
+        fieldName: "supportNeeded",
+        fieldset: {
+          legend: {
+            text: page.questions.supportNeeded.question,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: supportFollowUp
+          }
+        },
+        {
+          value: "no",
+          text: "No"
+        },
+        {
+          divider: 'or'
+        },
+        {
+          value: "dontKnow",
+          text: "I do not know"
+        }
+      ]
+      },
+      fetchContext()
+    )
+  }}
+
+    {{
+    formPageRadios(
+      {
+        fieldName: "receivingTreatment",
+        fieldset: {
+          legend: {
+            text: page.questions.receivingTreatment.question,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: treatmentFollowUp
+          }
+        },
+        {
+          value: "no",
+          text: "No"
+        },
+        {
+          divider: 'or'
+        },
+        {
+          value: "dontKnow",
+          text: "I do not know"
         }
       ]
       },
@@ -116,6 +209,13 @@
         {
           value: "no",
           text: "No"
+        },
+        {
+          divider: 'or'
+        },
+        {
+          value: "dontKnow",
+          text: "I do not know"
         }
       ]
       },
@@ -144,34 +244,13 @@
         {
           value: "no",
           text: "No"
-        }
-      ]
-      },
-      fetchContext()
-    )
-  }}
-
-  {{
-    formPageRadios(
-      {
-        fieldName: "requiresAdditionalSupport",
-        fieldset: {
-          legend: {
-            text: page.questions.requiresAdditionalSupport.question,
-            classes: "govuk-fieldset__legend--m"
-          }
-        },
-        items: [
-        {
-          value: "yes",
-          text: "Yes",
-          conditional: {
-            html: addSupportFollowUp
-          }
         },
         {
-          value: "no",
-          text: "No"
+          divider: 'or'
+        },
+        {
+          value: "dontKnow",
+          text: "I do not know"
         }
       ]
       },


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-285

# Changes in this PR

Updates the brain injury page questions.

I haven't altered the position of the heading as per the designs. That would require changes to all the health needs pages so I'll add a ticket to the backlog for that.

## Screenshots of UI changes

### Before

<img width="627" alt="Screenshot 2025-03-06 at 15 39 43" src="https://github.com/user-attachments/assets/351cd9d9-dcca-40a4-b898-1fd36a87c383" />

### After

<img width="653" alt="Screenshot 2025-03-06 at 15 39 13" src="https://github.com/user-attachments/assets/c87ea4fc-2a7c-445c-aab4-5a66271a7bb1" />

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
