### PR TITLE
Rename deploy environment input

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -69,7 +69,7 @@ jobs:
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
     secrets: inherit
     with:
-      environment: 'development'
+      environment: 'dev'
       app_version: '${{ needs.build.outputs.app_version }}'
   node_e2e_tests:
     name: Node e2e tests


### PR DESCRIPTION
# Context
A recent change to the one of the github actions we rely on for
deployment has changed the way the input for the environment is
accessed[1].

Previously, our workflow would default to `dev` which would correctly
retrieve our yaml file, however, as this is now accessing directly from
the explicitly set input, we need those to match.

[1]https://github.com/ministryofjustice/hmpps-github-actions/commit/2e7fb60d746fa9f8ba079496f528af475531a0ec#diff-67584b6afa3fa98aadfae64e1d36cc98f7811b88407a04efd2c4c149489e2d51R117-R120

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
