### PR TITLE
Ensure assess e2e uses recent submitted application

### DIFF
--- a/e2e-tests/steps/assess.ts
+++ b/e2e-tests/steps/assess.ts
@@ -13,6 +13,7 @@ export const updateStatus = async (page: Page) => {
 export const viewSubmittedApplication = async (page: Page) => {
   await page.goto('/assess/applications')
   await expect(page.locator('h1')).toContainText('Short-Term Accommodation (CAS-2) applications')
+  await page.getByTestId('pagination-page-number-link').last().click()
   await page.getByTestId('submitted-applications').getByRole('link').first().click()
   await page.getByRole('button', { name: 'View submitted application' }).click()
   await expect(page.locator('h1')).toContainText(`application`)

--- a/e2e-tests/tests/03_assess.spec.ts
+++ b/e2e-tests/tests/03_assess.spec.ts
@@ -4,10 +4,6 @@ import { test } from '../test'
 import { signIn } from '../steps/signIn'
 
 test('view a submitted application as an assessor', async ({ page, assessorUser }) => {
-  // Expect failing test due to old application data
-  // The first submitted application comes back as Person Not Found
-  test.fail(Boolean(process.env.CI), 'Failing due to Person Not Found 404')
-
   await signIn(page, assessorUser)
   await viewSubmittedApplication(page)
   await updateStatus(page)

--- a/server/utils/pagination.test.ts
+++ b/server/utils/pagination.test.ts
@@ -13,8 +13,8 @@ describe('pagination', () => {
     expect(pagination(1, 2, '?a=b&')).toEqual<Pagination>({
       next: { href: '?a=b&page=2' },
       items: [
-        { number: 1, href: '?a=b&page=1', current: true },
-        { number: 2, href: '?a=b&page=2' },
+        { number: 1, href: '?a=b&page=1', current: true, attributes: { 'data-testid': 'pagination-page-number-link' } },
+        { number: 2, href: '?a=b&page=2', attributes: { 'data-testid': 'pagination-page-number-link' } },
       ],
     })
   })
@@ -23,8 +23,8 @@ describe('pagination', () => {
     expect(pagination(2, 2, '?a=b&')).toEqual<Pagination>({
       previous: { href: '?a=b&page=1' },
       items: [
-        { number: 1, href: '?a=b&page=1' },
-        { number: 2, href: '?a=b&page=2', current: true },
+        { number: 1, href: '?a=b&page=1', attributes: { 'data-testid': 'pagination-page-number-link' } },
+        { number: 2, href: '?a=b&page=2', current: true, attributes: { 'data-testid': 'pagination-page-number-link' } },
       ],
     })
   })
@@ -34,88 +34,88 @@ describe('pagination', () => {
       previous: { href: '?a=b&page=1' },
       next: { href: '?a=b&page=3' },
       items: [
-        { number: 1, href: '?a=b&page=1' },
-        { number: 2, href: '?a=b&page=2', current: true },
-        { number: 3, href: '?a=b&page=3' },
+        { number: 1, href: '?a=b&page=1', attributes: { 'data-testid': 'pagination-page-number-link' } },
+        { number: 2, href: '?a=b&page=2', current: true, attributes: { 'data-testid': 'pagination-page-number-link' } },
+        { number: 3, href: '?a=b&page=3', attributes: { 'data-testid': 'pagination-page-number-link' } },
       ],
     })
   })
 
   it('should work on page 1 of 7', () => {
     expect(pagination(1, 7, '?a=b&')).toHaveProperty('items', [
-      { number: 1, href: '?a=b&page=1', current: true },
-      { number: 2, href: '?a=b&page=2' },
+      { number: 1, href: '?a=b&page=1', current: true, attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 2, href: '?a=b&page=2', attributes: { 'data-testid': 'pagination-page-number-link' } },
       { ellipsis: true },
-      { number: 6, href: '?a=b&page=6' },
-      { number: 7, href: '?a=b&page=7' },
+      { number: 6, href: '?a=b&page=6', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 7, href: '?a=b&page=7', attributes: { 'data-testid': 'pagination-page-number-link' } },
     ])
   })
 
   it('should work on page 2 of 7', () => {
     expect(pagination(2, 7, '?a=b&')).toHaveProperty('items', [
-      { number: 1, href: '?a=b&page=1' },
-      { number: 2, href: '?a=b&page=2', current: true },
-      { number: 3, href: '?a=b&page=3' },
+      { number: 1, href: '?a=b&page=1', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 2, href: '?a=b&page=2', current: true, attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 3, href: '?a=b&page=3', attributes: { 'data-testid': 'pagination-page-number-link' } },
       { ellipsis: true },
-      { number: 6, href: '?a=b&page=6' },
-      { number: 7, href: '?a=b&page=7' },
+      { number: 6, href: '?a=b&page=6', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 7, href: '?a=b&page=7', attributes: { 'data-testid': 'pagination-page-number-link' } },
     ])
   })
 
   it('should work on page 3 of 7', () => {
     expect(pagination(3, 7, '?a=b&')).toHaveProperty('items', [
-      { number: 1, href: '?a=b&page=1' },
-      { number: 2, href: '?a=b&page=2' },
-      { number: 3, href: '?a=b&page=3', current: true },
-      { number: 4, href: '?a=b&page=4' },
+      { number: 1, href: '?a=b&page=1', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 2, href: '?a=b&page=2', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 3, href: '?a=b&page=3', current: true, attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 4, href: '?a=b&page=4', attributes: { 'data-testid': 'pagination-page-number-link' } },
       { ellipsis: true },
-      { number: 6, href: '?a=b&page=6' },
-      { number: 7, href: '?a=b&page=7' },
+      { number: 6, href: '?a=b&page=6', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 7, href: '?a=b&page=7', attributes: { 'data-testid': 'pagination-page-number-link' } },
     ])
   })
 
   it('should work on page 4 of 7', () => {
     expect(pagination(4, 7, '?a=b&')).toHaveProperty('items', [
-      { number: 1, href: '?a=b&page=1' },
-      { number: 2, href: '?a=b&page=2' },
-      { number: 3, href: '?a=b&page=3' },
-      { number: 4, href: '?a=b&page=4', current: true },
-      { number: 5, href: '?a=b&page=5' },
-      { number: 6, href: '?a=b&page=6' },
-      { number: 7, href: '?a=b&page=7' },
+      { number: 1, href: '?a=b&page=1', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 2, href: '?a=b&page=2', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 3, href: '?a=b&page=3', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 4, href: '?a=b&page=4', current: true, attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 5, href: '?a=b&page=5', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 6, href: '?a=b&page=6', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 7, href: '?a=b&page=7', attributes: { 'data-testid': 'pagination-page-number-link' } },
     ])
   })
 
   it('should work on page 5 of 7', () => {
     expect(pagination(5, 7, '?a=b&')).toHaveProperty('items', [
-      { number: 1, href: '?a=b&page=1' },
-      { number: 2, href: '?a=b&page=2' },
+      { number: 1, href: '?a=b&page=1', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 2, href: '?a=b&page=2', attributes: { 'data-testid': 'pagination-page-number-link' } },
       { ellipsis: true },
-      { number: 4, href: '?a=b&page=4' },
-      { number: 5, href: '?a=b&page=5', current: true },
-      { number: 6, href: '?a=b&page=6' },
-      { number: 7, href: '?a=b&page=7' },
+      { number: 4, href: '?a=b&page=4', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 5, href: '?a=b&page=5', current: true, attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 6, href: '?a=b&page=6', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 7, href: '?a=b&page=7', attributes: { 'data-testid': 'pagination-page-number-link' } },
     ])
   })
 
   it('should work on page 6 of 7', () => {
     expect(pagination(6, 7, '?a=b&')).toHaveProperty('items', [
-      { number: 1, href: '?a=b&page=1' },
-      { number: 2, href: '?a=b&page=2' },
+      { number: 1, href: '?a=b&page=1', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 2, href: '?a=b&page=2', attributes: { 'data-testid': 'pagination-page-number-link' } },
       { ellipsis: true },
-      { number: 5, href: '?a=b&page=5' },
-      { number: 6, href: '?a=b&page=6', current: true },
-      { number: 7, href: '?a=b&page=7' },
+      { number: 5, href: '?a=b&page=5', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 6, href: '?a=b&page=6', current: true, attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 7, href: '?a=b&page=7', attributes: { 'data-testid': 'pagination-page-number-link' } },
     ])
   })
 
   it('should work on page 7 of 7', () => {
     expect(pagination(7, 7, '?a=b&')).toHaveProperty('items', [
-      { number: 1, href: '?a=b&page=1' },
-      { number: 2, href: '?a=b&page=2' },
+      { number: 1, href: '?a=b&page=1', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 2, href: '?a=b&page=2', attributes: { 'data-testid': 'pagination-page-number-link' } },
       { ellipsis: true },
-      { number: 6, href: '?a=b&page=6' },
-      { number: 7, href: '?a=b&page=7', current: true },
+      { number: 6, href: '?a=b&page=6', attributes: { 'data-testid': 'pagination-page-number-link' } },
+      { number: 7, href: '?a=b&page=7', current: true, attributes: { 'data-testid': 'pagination-page-number-link' } },
     ])
   })
 })

--- a/server/utils/pagination.ts
+++ b/server/utils/pagination.ts
@@ -9,6 +9,7 @@ export type PaginationItem =
       number: number
       href: string
       current?: boolean
+      attributes?: Record<string, string>
     }
   | {
       ellipsis: true
@@ -69,6 +70,7 @@ export function pagination(currentPage: number, pageCount: number, hrefPrefix: s
       const item: PaginationItem = {
         number: somePage,
         href: `${hrefPrefix}page=${somePage}`,
+        attributes: { 'data-testid': 'pagination-page-number-link' },
       }
       if (somePage === currentPage) {
         item.current = true


### PR DESCRIPTION
# Context
In a previous commit[1], we attempted to mark this test as failing due to older application data resulting in a 404. However, this solution didn't work due to the test timing out.

Instead of marking as failing, we ensure the test chooses the most recent page of submitted applications which lowers the likelihood of selecting an older application.

A fix should still be implemented in the API to ensure all submitted applications are viewable.

[1]
https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui/commit/70a5d85492703ba9d6b905a39aaed8b6577fb732#diff-429df44951dd618e2cda8caf7d8af4feca0e6dcdd8bc7b85339ae6c7623dda4dR8-R9

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
