### PR TITLE
New client creds for test env

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -18,6 +18,11 @@ generic-service:
     ENVIRONMENT_NAME: TEST
     AUDIT_ENABLED: "false"
 
+  namespace_secrets:
+    hmpps-community-accommodation-tier-2-bail-ui:
+      AUTH_CODE_CLIENT_ID: 'API_CLIENT_ID'
+      AUTH_CODE_CLIENT_SECRET: 'API_CLIENT_SECRET'
+
   allowlist: null
 
 generic-prometheus-alerts:


### PR DESCRIPTION
# Context
Cannot currently log into test. After speaking with auth team they recommend trying to replace the client creds in the test env

# Changes in this PR

New client creds for test env

## Post merge

Once we've merged it will be auto-deployed to the dev environment. A manual push the test environment will need to be made to test this
