### PR TITLE
Revert "Update dependency chokidar to v4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "audit-ci": "^7.1.0",
     "aws-sdk-client-mock": "^4.1.0",
     "axe-core": "^4.10.3",
-    "chokidar": "^4.0.3",
+    "chokidar": "^3.6.0",
     "concurrently": "^9.1.2",
     "cypress": "^14.1.0",
     "cypress-axe": "^1.6.0",


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui#78.

It slipped through but is causing dependency conflict errors. I think we may as well wait and see if Nunjucks updates the version of Chokidar it's using.