### PR TITLE
Fix search by noms failure redirect

### DIFF
--- a/server/controllers/peopleController.test.ts
+++ b/server/controllers/peopleController.test.ts
@@ -174,7 +174,7 @@ describe('peopleController', () => {
   describe('findByCrn', () => {
     beforeEach(() => {
       request = createMock<Request>({
-        body: { crn, applicationOrigin },
+        body: { crn, applicationOrigin: 'courtBail' },
         user: { token },
         flash: flashSpy,
         headers: {
@@ -198,6 +198,7 @@ describe('peopleController', () => {
           person,
           date: DateFormats.dateObjtoUIDate(new Date()),
           dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+          applicationOrigin: 'courtBail',
         })
       })
 

--- a/server/controllers/peopleController.ts
+++ b/server/controllers/peopleController.ts
@@ -1,6 +1,6 @@
 import type { Request, RequestHandler, Response } from 'express'
 
-import { errorMessage, errorSummary } from '../utils/validation'
+import { addErrorMessagesToFlash } from '../utils/validation'
 import PersonService from '../services/personService'
 import ApplicationService from '../services/applicationService'
 import { DateFormats } from '../utils/dateUtils'
@@ -29,25 +29,25 @@ export default class PeopleController {
           })
         } catch (err) {
           if (err.status === 404) {
-            this.addErrorMessagesToFlash(
+            addErrorMessagesToFlash(
               req,
               'prisonNumber',
               `No person found for prison number ${prisonNumber}, please try another number.`,
             )
           } else if (err.status === 403) {
-            this.addErrorMessagesToFlash(
+            addErrorMessagesToFlash(
               req,
               'prisonNumber',
               `You do not have permission to access the prison number ${prisonNumber}, please try another number.`,
             )
           } else {
-            this.addErrorMessagesToFlash(req, 'prisonNumber', 'Something went wrong. Please try again later.')
+            addErrorMessagesToFlash(req, 'prisonNumber', 'Something went wrong. Please try again later.')
           }
 
           return res.redirect(paths.applications.searchByPrisonNumber({}))
         }
       } else {
-        this.addErrorMessagesToFlash(req, 'prisonNumber', 'Enter a prison number')
+        addErrorMessagesToFlash(req, 'prisonNumber', 'Enter a prison number')
         return res.redirect(paths.applications.searchByPrisonNumber({}))
       }
     }
@@ -70,31 +70,23 @@ export default class PeopleController {
           })
         } catch (err) {
           if (err.status === 404) {
-            this.addErrorMessagesToFlash(req, 'crn', `No person found for CRN ${crn}, please try another number.`)
+            addErrorMessagesToFlash(req, 'crn', `No person found for CRN ${crn}, please try another number.`)
           } else if (err.status === 403) {
-            this.addErrorMessagesToFlash(
+            addErrorMessagesToFlash(
               req,
               'crn',
               `You do not have permission to access the CRN ${crn}, please try another number.`,
             )
           } else {
-            this.addErrorMessagesToFlash(req, 'crn', 'Something went wrong. Please try again later.')
+            addErrorMessagesToFlash(req, 'crn', 'Something went wrong. Please try again later.')
           }
 
           return res.redirect(paths.applications.searchByCrn({}))
         }
       } else {
-        this.addErrorMessagesToFlash(req, 'crn', 'Enter a CRN')
+        addErrorMessagesToFlash(req, 'crn', 'Enter a CRN')
         return res.redirect(paths.applications.searchByCrn({}))
       }
     }
-  }
-
-  addErrorMessagesToFlash(request: Request, key: string, message: string) {
-    request.flash('errors', {
-      [key]: errorMessage(key, message),
-    })
-    request.flash('errorSummary', [errorSummary(key, message)])
-    request.flash('userInput', request.body)
   }
 }

--- a/server/controllers/peopleController.ts
+++ b/server/controllers/peopleController.ts
@@ -55,7 +55,7 @@ export default class PeopleController {
 
   findByCrn(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { crn } = req.body
+      const { crn, applicationOrigin } = req.body
 
       if (crn) {
         try {
@@ -66,6 +66,7 @@ export default class PeopleController {
             person,
             date: DateFormats.dateObjtoUIDate(new Date()),
             dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+            applicationOrigin,
           })
         } catch (err) {
           if (err.status === 404) {

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -4,6 +4,7 @@ import type { ErrorMessages, ErrorSummary } from '@approved-premises/ui'
 import { SanitisedError } from 'server/sanitisedError'
 import TaskListPage from 'server/form-pages/taskListPage'
 import {
+  addErrorMessagesToFlash,
   catchAPIErrorOrPropogate,
   catchValidationErrorOrPropogate,
   fetchErrorsAndUserInput,
@@ -237,5 +238,29 @@ describe('firstFlashItem', () => {
 
       expect(result).toBe(undefined)
     })
+  })
+})
+
+describe('addErrorMessagesToFlash', () => {
+  it('adds error messages to flash object', () => {
+    const key = 'name'
+    const message = 'Please enter a name'
+
+    const request = createMock<Request>({})
+    request.flash = jest.fn()
+    request.body = { field: 'value' }
+
+    addErrorMessagesToFlash(request, key, message)
+
+    expect(request.flash).toHaveBeenCalledWith('errors', {
+      [key]: {
+        attributes: {
+          'data-cy-error-name': true,
+        },
+        text: 'Please enter a name',
+      },
+    })
+    expect(request.flash).toHaveBeenCalledWith('errorSummary', [{ href: '#name', text: 'Please enter a name' }])
+    expect(request.flash).toHaveBeenCalledWith('userInput', { field: 'value' })
   })
 })

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -78,6 +78,14 @@ export const errorSummary = (field: string, text: string): ErrorSummary => {
   }
 }
 
+export const addErrorMessagesToFlash = (request: Request, key: string, message: string): void => {
+  request.flash('errors', {
+    [key]: errorMessage(key, message),
+  })
+  request.flash('errorSummary', [errorSummary(key, message)])
+  request.flash('userInput', request.body)
+}
+
 export const generateErrorMessages = (errors: Record<string, string>): ErrorMessages => {
   return Object.keys(errors).reduce((obj, key) => {
     return {


### PR DESCRIPTION
[JIRA](https://dsdmoj.atlassian.net/browse/CBA-374?atlOrigin=eyJpIjoiMjY5ZTg3NzcyZjBlNGViYjljYTM3YzI3Y2VkYzcxODYiLCJwIjoiaiJ9)

# Context
Previously, if you were to enter a CRN, and encounter an error creating
the application, you'd be bounced back to the prison number page. This
change implements:

* If applicationOrigin is courtBail, redirect to findByCrn page
* If applicationOrigin is prisonBail, redirect to findByPrisonNumber
  page
* applicationOrigin is not known, redirect to applicationOrigin page

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
