### PR TITLE
CBA-264 add content to living in the community page

### DIFF
--- a/e2e-tests/steps/risksAndNeedsSection.ts
+++ b/e2e-tests/steps/risksAndNeedsSection.ts
@@ -132,7 +132,7 @@ export const completeRiskInformationTask = async (page: Page, name: string) => {
   await completeSelfHarmPage(page, name)
   await addAnAcct(page)
   await completeViolenceAndArsonPage(page, name)
-  await completeLivingInTheCommunityPage(page)
+  await completeLivingInTheCommunityPage(page, name)
   await completeSafetyOfStaffPage(page)
   await completeAdditionalConcernsPage(page)
 }
@@ -162,8 +162,19 @@ async function completeViolenceAndArsonPage(page: Page, name: string) {
   violenceAndArsonPage.clickSave()
 }
 
-async function completeLivingInTheCommunityPage(page: Page) {
-  const livingInTheCommunityPage = await ApplyPage.initialize(page, 'Living in the community')
+async function completeLivingInTheCommunityPage(page: Page, name: string) {
+  const livingInTheCommunityPage = await ApplyPage.initialize(
+    page,
+    `Concerns related to ${name} living in the community`,
+  )
+
+  await livingInTheCommunityPage.checkRadioInGroup(
+    'convictions or behaviours noted related to aggression or hate',
+    'No',
+  )
+  await livingInTheCommunityPage.checkRadioInGroup('victim of violence, bullying, or intimidation', 'No')
+  await livingInTheCommunityPage.checkRadioInGroup('any other concerns', 'No')
+  await livingInTheCommunityPage.checkRadioInGroup('Cell Sharing Risk Assessment', 'No')
 
   livingInTheCommunityPage.clickSave()
 }

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -231,7 +231,16 @@
       "currentConcerns": "no",
       "currentConcernsDetail": ""
     },
-    "living-in-the-community": {},
+    "living-in-the-community": {
+      "convictionsRelatedToHateOrAggression": "no",
+      "convictionsDetail": "",
+      "victimOfOthers": "no",
+      "victimOfOthersDetail": "",
+      "otherConcerns": "no",
+      "otherConcernsDetail": "",
+      "cellSharingRiskAssessment": "no",
+      "cellSharingRiskAssessmentDetail": ""
+    },
     "safety-of-staff": {
       "pastRiskToStaff": "no",
       "pastRiskToStaffDetail": "",

--- a/integration_tests/pages/apply/risks-and-needs/risk-information/livingInTheCommunityPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-information/livingInTheCommunityPage.ts
@@ -1,8 +1,59 @@
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import ApplyPage from '../../applyPage'
+import paths from '../../../../../server/paths/apply'
+import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 
 export default class LivingInTheCommunityPage extends ApplyPage {
   constructor(private readonly application: Application) {
-    super('Living in the community', application, 'risk-information', 'living-in-the-community')
+    super(
+      `Concerns related to ${nameOrPlaceholderCopy(application.person)} living in the community`,
+      application,
+      'risk-information',
+      'living-in-the-community',
+    )
+  }
+
+  static visit(application: Application): LivingInTheCommunityPage {
+    cy.visit(
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'risk-information',
+        page: 'living-in-the-community',
+      }),
+    )
+
+    return new LivingInTheCommunityPage(application)
+  }
+
+  hasGuidanceText = (): void => {
+    cy.get('.guidance').contains('behaviours that might impact any of')
+    cy.get('.guidance').contains('victims')
+    cy.get('.guidance').contains('known adults')
+    cy.get('.guidance').contains('children')
+    cy.get('.guidance').contains('residents of shared accommodation')
+    cy.get('.guidance').contains('members of the LGBTQ+ community')
+    cy.get('.guidance').contains('public')
+    cy.get('.guidance').contains('specific ethnic minorities or religious groups')
+    cy.get('.guidance').contains('not exhaustive')
+  }
+
+  enterConvictionDetails = (): void => {
+    this.checkRadioByNameAndValue('convictionsRelatedToHateOrAggression', 'yes')
+    this.getTextInputByIdAndEnterDetails('convictionsDetail', 'some details')
+  }
+
+  enterVictimDetails = (): void => {
+    this.checkRadioByNameAndValue('victimOfOthers', 'yes')
+    this.getTextInputByIdAndEnterDetails('victimOfOthersDetail', 'some details')
+  }
+
+  enterOtherConcerns = (): void => {
+    this.checkRadioByNameAndValue('otherConcerns', 'yes')
+    this.getTextInputByIdAndEnterDetails('otherConcernsDetail', 'some details')
+  }
+
+  enterCSRADetails = (): void => {
+    this.checkRadioByNameAndValue('cellSharingRiskAssessment', 'yes')
+    this.getTextInputByIdAndEnterDetails('cellSharingRiskAssessmentDetail', 'some details')
   }
 }

--- a/integration_tests/tests/apply/risks-and-needs/risk-information/complete_living_in_the_community_page.cy.ts
+++ b/integration_tests/tests/apply/risks-and-needs/risk-information/complete_living_in_the_community_page.cy.ts
@@ -1,9 +1,26 @@
-//  Feature: complete living in the community page
+//  Feature: Referrer completes 'Living in the community' page
+//    So that I can complete the "Risk" task
+//    As a referrer
+//    I want to complete the 'Living in the community' page
 //
+//  Background:
+//    Given an application exists
+//    And I am logged in
+//    And I am on the 'Living in the community' page
+//
+//  Scenario: view Living in the community page
+//    Then I see the "Living in the community" page
+//    And I see guidance text
+//
+//  Scenario: complete page and navigate to next page in risk task
+//    When I complete the Living in the community page
+//    And I continue to the next task / page
+//    Then I see the "safety of staff" page
 
 import LivingInTheCommunityPage from '../../../../pages/apply/risks-and-needs/risk-information/livingInTheCommunityPage'
 import Page from '../../../../pages/page'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import SafetyOfStaffPage from '../../../../pages/apply/risks-and-needs/risk-information/safetyOfStaffPage'
 
 context('Complete "Living in the community" page', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
@@ -34,13 +51,33 @@ context('Complete "Living in the community" page', () => {
     //---------------------
     cy.signIn()
 
-    // And I visit the Living in the community page
+    // And I am on the 'Living in the community' page
     // --------------------------------
-    cy.visit('applications/abc123/tasks/risk-information/pages/living-in-the-community')
+    LivingInTheCommunityPage.visit(this.application)
   })
 
-  it('exists', function test() {
-    // Given I am on the Living in the community page
-    Page.verifyOnPage(LivingInTheCommunityPage, this.application)
+  //  Scenario: view Living in the community page
+  it('shows the page', function test() {
+    //  Then I see the Living in the community page
+    const page = Page.verifyOnPage(LivingInTheCommunityPage, this.application)
+
+    //  And I see guidance text
+    page.hasGuidanceText()
+  })
+
+  //  Scenario: complete page and navigate to next page in risk task
+  it('continues to the next page', function test() {
+    const page = Page.verifyOnPage(LivingInTheCommunityPage, this.application)
+    //  When I complete the Living in the community page
+    page.enterConvictionDetails()
+    page.enterVictimDetails()
+    page.enterOtherConcerns()
+    page.enterCSRADetails()
+
+    //  And I continue to the next task / page
+    page.clickSubmit()
+
+    //  Then I see the "safety of staff" page
+    Page.verifyOnPage(SafetyOfStaffPage, this.application)
   })
 })

--- a/server/form-pages/apply/risks-and-needs/risk-information/livingInTheCommunity.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-information/livingInTheCommunity.test.ts
@@ -1,6 +1,6 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
-import LivingInTheCommunity from './livingInTheCommunity'
+import LivingInTheCommunity, { LivingInTheCommunityBody } from './livingInTheCommunity'
 
 describe('LivingInTheCommunity', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
@@ -9,10 +9,163 @@ describe('LivingInTheCommunity', () => {
     it('adds the page title', () => {
       const page = new LivingInTheCommunity({}, application)
 
-      expect(page.title).toEqual('Living in the community')
+      expect(page.title).toEqual(`Concerns related to Roger Smith living in the community`)
     })
   })
 
   itShouldHaveNextValue(new LivingInTheCommunity({}, application), 'safety-of-staff')
   itShouldHavePreviousValue(new LivingInTheCommunity({}, application), 'violence-and-arson')
+
+  describe('errors', () => {
+    describe('when top-level questions are unanswered', () => {
+      const page = new LivingInTheCommunity({}, application)
+
+      it('includes a validation error for _convictionsRelatedToHateOrAggression_', () => {
+        expect(page.errors()).toHaveProperty(
+          'convictionsRelatedToHateOrAggression',
+          `Select if they have had any convictions or behaviours related to aggression or hate towards others`,
+        )
+      })
+
+      it('includes a validation error for _victimOfOthers_', () => {
+        expect(page.errors()).toHaveProperty(
+          'victimOfOthers',
+          `Select if they have been a victim of violence, bullying, or intimidation from others`,
+        )
+      })
+
+      it('includes a validation error for _otherConcerns_', () => {
+        expect(page.errors()).toHaveProperty(
+          'otherConcerns',
+          'Select if there are other concerns with the applicant living in the community',
+        )
+      })
+
+      it('includes a validation error for _cellSharingRiskAssessment_', () => {
+        expect(page.errors()).toHaveProperty(
+          'cellSharingRiskAssessment',
+          `Select if a Cell Sharing Risk Assessment (CSRA) has been done`,
+        )
+      })
+    })
+
+    describe('when _convictionsRelatedToHateOrAggression_ is YES', () => {
+      const page = new LivingInTheCommunity({ convictionsRelatedToHateOrAggression: 'yes' }, application)
+
+      describe('and _convictionsDetail_ is UNANSWERED', () => {
+        it('includes a validation error for _convictionsDetail_', () => {
+          expect(page.errors()).toHaveProperty(
+            'convictionsDetail',
+            'Enter the details of convictions or behaviours related to aggression or hate towards others',
+          )
+        })
+      })
+    })
+
+    describe('when _victimOfOthers_ is YES', () => {
+      const page = new LivingInTheCommunity({ victimOfOthers: 'yes' }, application)
+
+      describe('and _victimOfOthersDetail_ is UNANSWERED', () => {
+        it('includes a validation error for _victimOfOthersDetail_', () => {
+          expect(page.errors()).toHaveProperty(
+            'victimOfOthersDetail',
+            'Enter the details about the applicant being a victim of violence, bullying, or intimidation',
+          )
+        })
+      })
+    })
+
+    describe('when _otherConcerns_ is YES', () => {
+      const page = new LivingInTheCommunity({ otherConcerns: 'yes' }, application)
+
+      describe('and _otherConcernsDetail_ is UNANSWERED', () => {
+        it('includes a validation error for _otherConcernsDetail_', () => {
+          expect(page.errors()).toHaveProperty('otherConcernsDetail', 'Enter details of current concerns')
+        })
+      })
+    })
+
+    describe('when _cellSharingRiskAssessment_ is YES', () => {
+      const page = new LivingInTheCommunity({ cellSharingRiskAssessment: 'yes' }, application)
+
+      describe('and _cellSharingRiskAssessmentDetail_ is UNANSWERED', () => {
+        it('includes a validation error for _cellSharingRiskAssessmentDetail_', () => {
+          expect(page.errors()).toHaveProperty(
+            'cellSharingRiskAssessmentDetail',
+            'Enter the concerns around sharing communal areas',
+          )
+        })
+      })
+    })
+  })
+
+  describe('onSave', () => {
+    describe('when _convictionsRelatedToHateOrAggression_ is NO', () => {
+      it('removes convictionsDetail answer', () => {
+        const body: Partial<LivingInTheCommunityBody> = {
+          convictionsRelatedToHateOrAggression: 'no',
+          convictionsDetail: 'some details',
+        }
+
+        const page = new LivingInTheCommunity(body, application)
+
+        page.onSave()
+
+        expect(page.body).toEqual({
+          convictionsRelatedToHateOrAggression: 'no',
+        })
+      })
+    })
+
+    describe('when _victimOfOthers_ is NO', () => {
+      it('removes victimOfOthersDetail answer', () => {
+        const body: Partial<LivingInTheCommunityBody> = {
+          victimOfOthers: 'no',
+          victimOfOthersDetail: 'some details',
+        }
+
+        const page = new LivingInTheCommunity(body, application)
+
+        page.onSave()
+
+        expect(page.body).toEqual({
+          victimOfOthers: 'no',
+        })
+      })
+    })
+
+    describe('when _otherConcerns_ is NO', () => {
+      it('removes otherConcernsDetail answer', () => {
+        const body: Partial<LivingInTheCommunityBody> = {
+          otherConcerns: 'no',
+          otherConcernsDetail: 'some details',
+        }
+
+        const page = new LivingInTheCommunity(body, application)
+
+        page.onSave()
+
+        expect(page.body).toEqual({
+          otherConcerns: 'no',
+        })
+      })
+    })
+
+    describe('when _cellSharingRiskAssessment_ is NO', () => {
+      it('removes cellSharingRiskAssessmentDetail answer', () => {
+        const body: Partial<LivingInTheCommunityBody> = {
+          cellSharingRiskAssessment: 'no',
+          cellSharingRiskAssessmentDetail: 'some details',
+        }
+
+        const page = new LivingInTheCommunity(body, application)
+
+        page.onSave()
+
+        expect(page.body).toEqual({
+          cellSharingRiskAssessment: 'no',
+        })
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/risks-and-needs/risk-information/livingInTheCommunity.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-information/livingInTheCommunity.ts
@@ -1,23 +1,40 @@
-import type { TaskListErrors } from '@approved-premises/ui'
+import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 import { getQuestions } from '../../../utils/questions'
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-type LivingInTheCommunityBody = {}
+export type LivingInTheCommunityBody = {
+  convictionsRelatedToHateOrAggression: YesOrNo
+  convictionsDetail: string
+  victimOfOthers: YesOrNo
+  victimOfOthersDetail: string
+  otherConcerns: YesOrNo
+  otherConcernsDetail: string
+  cellSharingRiskAssessment: 'yes' | 'no' | 'notInPrisonCustody'
+  cellSharingRiskAssessmentDetail: string
+}
 
 @Page({
   name: 'living-in-the-community',
-  bodyProperties: [],
+  bodyProperties: [
+    'convictionsRelatedToHateOrAggression',
+    'convictionsDetail',
+    'victimOfOthers',
+    'victimOfOthersDetail',
+    'otherConcerns',
+    'otherConcernsDetail',
+    'cellSharingRiskAssessment',
+    'cellSharingRiskAssessmentDetail',
+  ],
 })
 export default class LivingInTheCommunity implements TaskListPage {
   documentTitle = 'Living in the community'
 
   personName = nameOrPlaceholderCopy(this.application.person)
 
-  title = 'Living in the community'
+  title = `Concerns related to ${this.personName} living in the community`
 
   questions = getQuestions(this.personName)['risk-information']['living-in-the-community']
 
@@ -41,6 +58,59 @@ export default class LivingInTheCommunity implements TaskListPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
+    if (!this.body.convictionsRelatedToHateOrAggression) {
+      errors.convictionsRelatedToHateOrAggression =
+        'Select if they have had any convictions or behaviours related to aggression or hate towards others'
+    }
+
+    if (this.body.convictionsRelatedToHateOrAggression === 'yes' && !this.body.convictionsDetail) {
+      errors.convictionsDetail =
+        'Enter the details of convictions or behaviours related to aggression or hate towards others'
+    }
+
+    if (!this.body.victimOfOthers) {
+      errors.victimOfOthers = 'Select if they have been a victim of violence, bullying, or intimidation from others'
+    }
+
+    if (this.body.victimOfOthers === 'yes' && !this.body.victimOfOthersDetail) {
+      errors.victimOfOthersDetail =
+        'Enter the details about the applicant being a victim of violence, bullying, or intimidation'
+    }
+
+    if (!this.body.otherConcerns) {
+      errors.otherConcerns = 'Select if there are other concerns with the applicant living in the community'
+    }
+
+    if (this.body.otherConcerns === 'yes' && !this.body.otherConcernsDetail) {
+      errors.otherConcernsDetail = 'Enter details of current concerns'
+    }
+
+    if (!this.body.cellSharingRiskAssessment) {
+      errors.cellSharingRiskAssessment = 'Select if a Cell Sharing Risk Assessment (CSRA) has been done'
+    }
+
+    if (this.body.cellSharingRiskAssessment === 'yes' && !this.body.cellSharingRiskAssessmentDetail) {
+      errors.cellSharingRiskAssessmentDetail = 'Enter the concerns around sharing communal areas'
+    }
+
     return errors
+  }
+
+  onSave(): void {
+    if (this.body.convictionsRelatedToHateOrAggression !== 'yes') {
+      delete this.body.convictionsDetail
+    }
+
+    if (this.body.victimOfOthers !== 'yes') {
+      delete this.body.victimOfOthersDetail
+    }
+
+    if (this.body.otherConcerns !== 'yes') {
+      delete this.body.otherConcernsDetail
+    }
+
+    if (this.body.cellSharingRiskAssessment !== 'yes') {
+      delete this.body.cellSharingRiskAssessmentDetail
+    }
   }
 }

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -736,7 +736,6 @@ export const getQuestions = (name: string) => {
           question: 'Enter the details of any current concerns',
         },
       },
-      'living-in-the-community': {},
       'safety-of-staff': {
         pastRiskToStaff: {
           question: `Has ${name} posed a risk to the safety of any staff in the past?`,
@@ -755,6 +754,44 @@ export const getQuestions = (name: string) => {
           question: 'Enter the details of any current concerns',
         },
       },
+      'living-in-the-community': {
+        convictionsRelatedToHateOrAggression: {
+          question:
+            'Has the applicant had any convictions or behaviours noted related to aggression or hate towards others in the past?',
+          hint: 'This includes any incidents prior to being held in custody.',
+          answers: yesOrNo,
+        },
+        convictionsDetail: {
+          question:
+            'Enter details, including if they have a history of bullying, intimidation or controlling behaviour',
+          hint: 'This includes any discrimination or abuse based on identity. For example, ethnicity, religion or sexuality.',
+        },
+        victimOfOthers: {
+          question:
+            'Based on the information you have, has the applicant ever been a victim of violence, bullying, or intimidation from others?',
+          answers: yesOrNo,
+        },
+        victimOfOthersDetail: {
+          question: 'Enter details, including any vulnerabilities that might make them a target for harm',
+        },
+        otherConcerns: {
+          question:
+            'Based on the information you have, are there any other concerns with the applicant living in the community?',
+          hint: 'This includes any concerns whilst being held in custody.',
+          answers: yesOrNo,
+        },
+        otherConcernsDetail: {
+          question: 'Enter the details of any current concerns',
+        },
+        cellSharingRiskAssessment: {
+          question: 'Has a Cell Sharing Risk Assessment (CSRA) been done?',
+          answers: { yes: 'Yes', no: 'No', notInPrisonCustody: 'No, the applicant is not in prison custody' },
+        },
+        cellSharingRiskAssessmentDetail: {
+          question: 'Enter any concerns around the applicant sharing communal areas with other residents',
+        },
+      },
+      'risks-to-staff': {},
       'additional-concerns': {},
       'acct-data': {
         createdDate: {

--- a/server/views/applications/pages/risk-information/living-in-the-community.njk
+++ b/server/views/applications/pages/risk-information/living-in-the-community.njk
@@ -2,4 +2,200 @@
 {% set pageName = "living-in-the-community" %}
 
 {% block questions %}
+
+  {% set convictionsRelatedToHateOrAggressionFollowUp %}
+  {{
+      formPageTextArea(
+        {
+          fieldName: 'convictionsDetail',
+          label: {
+            text: page.questions.convictionsDetail.question,
+            classes: "govuk-label--s"
+          },
+          hint: {
+            text: page.questions.convictionsDetail.hint
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset %}
+
+  {% set victimOfOthersFollowUp %}
+    {{
+      formPageTextArea(
+        {
+          fieldName: 'victimOfOthersDetail',
+          label: {
+            text: page.questions.victimOfOthersDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset %}
+
+    {% set otherConcernsFollowUp %}
+    {{
+      formPageTextArea(
+        {
+          fieldName: 'otherConcernsDetail',
+          label: {
+            text: page.questions.otherConcernsDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset %}
+
+    {% set cellSharingRiskAssessmentFollowUp %}
+    {{
+      formPageTextArea(
+        {
+          fieldName: 'cellSharingRiskAssessmentDetail',
+          label: {
+            text: page.questions.cellSharingRiskAssessmentDetail.question,
+            classes: "govuk-label--s"
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset %}
+
+   <div class="guidance govuk-hint govuk-!-margin-bottom-6">
+    <p class="govuk-hint govuk-!-margin-bottom-1">This can include any behaviours that might impact any of the following groups:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-hint govuk-!-margin-bottom-6">
+      <li>victims</li>
+      <li>known adults</li>
+      <li>children</li>
+      <li>other residents of shared accommodation</li>
+      <li>members of the LGBTQ+ community</li>
+      <li>the public</li>
+      <li>specific ethnic minorities or religious groups</li>
+    </ul>
+    <p class="govuk-hint">This list is not exhaustive.</p>
+  </div>
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "convictionsRelatedToHateOrAggression",
+        fieldset: {
+          legend: {
+            text: page.questions.convictionsRelatedToHateOrAggression.question,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        hint: { text: page.questions.convictionsRelatedToHateOrAggression.hint },
+        items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: convictionsRelatedToHateOrAggressionFollowUp
+          }
+        },
+        {
+          value: "no",
+          text: "No"
+        }
+      ]
+      },
+      fetchContext()
+    )
+  }}
+
+    {{
+    formPageRadios(
+      {
+        fieldName: "victimOfOthers",
+        fieldset: {
+          legend: {
+            text: page.questions.victimOfOthers.question,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: victimOfOthersFollowUp
+          }
+        },
+        {
+          value: "no",
+          text: "No"
+        }
+      ]
+      },
+      fetchContext()
+    )
+  }}
+
+    {{
+    formPageRadios(
+      {
+        fieldName: "otherConcerns",
+        fieldset: {
+          legend: {
+            text: page.questions.otherConcerns.question,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        hint: { text: page.questions.otherConcerns.hint },
+        items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: otherConcernsFollowUp
+          }
+        },
+        {
+          value: "no",
+          text: "No"
+        }
+      ]
+      },
+      fetchContext()
+    )
+  }}
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "cellSharingRiskAssessment",
+        fieldset: {
+          legend: {
+            text: page.questions.cellSharingRiskAssessment.question,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: cellSharingRiskAssessmentFollowUp
+          }
+        },
+        {
+          value: "no",
+          text: "No"
+        },
+        {
+          value: "notInPrisonCustody",
+          text: "No, the applicant is not in prison custody"
+        }
+      ]
+      },
+      fetchContext()
+    )
+  }}
+
 {% endblock %}


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-264

# Changes in this PR

Adds questions to living in the community page in the risk section.

## Screenshots of UI changes

![Screenshot 2025-03-18 at 14 40 36](https://github.com/user-attachments/assets/a76457d1-fc25-41aa-8f50-e14d61d9c05f)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
