### PR TITLE
Install dependencies for e2e tests if cache fails

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -36,6 +36,11 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+      - name: install dependencies
+        if: steps.refresh-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          npm ci --no-audit
       - name: install playwright
         shell: bash
         run: |

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -36,20 +36,6 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - name: Grep node_modules playwright
-        shell: bash
-        run: |
-          ls -la node_modules/ | grep 'playwright'
-      - name: Log size of node_modules
-        shell: bash
-        run: |
-          du -sh node_modules/
-      - name: upload node_modules dump
-        uses: actions/upload-artifact@v4
-        with:
-          name: node_modules_dump
-          path: |
-            node_modules/
       - name: install playwright
         shell: bash
         run: |


### PR DESCRIPTION
# Context
Our [e2e test in github actions](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui/actions/runs/13925802562/job/38975285439) is reporting the following error

```
Error: Cannot find module '@playwright/test'
```

Which is due to the workflow not being able to retrieve the `node_modules` cache, even though the `integration_test` workflow is able to retrieve the cache with the exact same key.

## Integration test
```
Cache hit for: Linux-build-node-modules-8c55835dd02886b830d976f91098cb7ad63ae19fd9dde0a4277f2a860c749ddb
Received 218103808 of 263718395 (82.7%), 205.5 MBs/sec
Received 263718395 of 263718395 (100.0%), 209.4 MBs/sec
Cache Size: ~252 MB (263718395 B)
/usr/bin/tar -xf /home/runner/work/_temp/e07833c0-36[16](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui/actions/runs/13925802562/job/38974092000#step:5:17)-4db4-a41c-4e76f898a3dc/cache.tzst -P -C /home/runner/work/hmpps-community-accommodation-tier-2-bail-ui/hmpps-community-accommodation-tier-2-bail-ui --use-compress-program unzstd
Cache restored successfully
Cache restored from key: Linux-build-node-modules-8c55835dd02886b830d976f91098cb7ad63ae19fd9dde0a4277f2a860c749ddb
```

## e2e test
```
Cache not found for input keys: Linux-build-node-modules-8c55835dd02886b830d976f91098cb7ad63ae19fd9dde0a4277f2a860c749ddb, Linux-build-node-modules-, Linux-build-, Linux-
```

This requires more investigation, but in the meantime to unblock the pipeline, this change will allow the e2e test workflow to install dependencies again if the cache can't be found.

# Changes in this PR
* Install dependencies for e2e tests if cache fails

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
