### PR TITLE
Update cancellation assertion in E2E tests

### DIFF
--- a/e2e-tests/tests/01_apply_as_nomis_prison_user.spec.ts
+++ b/e2e-tests/tests/01_apply_as_nomis_prison_user.spec.ts
@@ -49,10 +49,9 @@ test('cancel an in progress application from the task list', async ({ page, nomi
   await signIn(page, nomisPrisonUser)
   await createAnInProgressApplication(page, person, 'prisonBail')
   await viewInProgressDashboard(page)
-  const numberOfApplicationsBeforeCancellation = (await page.locator('tr').all()).length
   await clickCancel(page, person.name)
   await cancelAnApplication(page, person.name)
-  const numberOfApplicationsAfterCancellation = (await page.locator('tr').all()).length
   await expect(page.getByText('Your CAS-2 applications')).toBeVisible()
-  expect(numberOfApplicationsBeforeCancellation - numberOfApplicationsAfterCancellation).toEqual(1)
+  await expect(page.locator('h2').first()).toContainText('Success')
+  await expect(page.locator('h3').first()).toContainText(`The application for ${person.name} has been cancelled.`)
 })

--- a/e2e-tests/tests/02_apply_as_nomis_court_user.spec.ts
+++ b/e2e-tests/tests/02_apply_as_nomis_court_user.spec.ts
@@ -49,10 +49,9 @@ test('cancel an in progress application from the task list', async ({ page, nomi
   await signIn(page, nomisCourtUser)
   await createAnInProgressApplication(page, person, 'courtBail')
   await viewInProgressDashboard(page)
-  const numberOfApplicationsBeforeCancellation = (await page.locator('tr').all()).length
   await clickCancel(page, person.name)
   await cancelAnApplication(page, person.name)
-  const numberOfApplicationsAfterCancellation = (await page.locator('tr').all()).length
   await expect(page.getByText('Your CAS-2 applications')).toBeVisible()
-  expect(numberOfApplicationsBeforeCancellation - numberOfApplicationsAfterCancellation).toEqual(1)
+  await expect(page.locator('h2').first()).toContainText('Success')
+  await expect(page.locator('h3').first()).toContainText(`The application for ${person.name} has been cancelled.`)
 })


### PR DESCRIPTION
The previous assertion was brittle and causing false failures in CI. We have replaced it with an assertion based on the success banner.

# Context

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
