### PR TITLE
CBA-306: show standard id page regardless of payment method selected on funding cas 2 page

### DIFF
--- a/e2e-tests/steps/areaAndFundingSection.ts
+++ b/e2e-tests/steps/areaAndFundingSection.ts
@@ -5,12 +5,26 @@ export const completeFundingInformationTask = async (page: Page) => {
   const taskListPage = new TaskListPage(page)
   await taskListPage.clickTask('Confirm funding and ID')
 
+  await completeFundingInformationPage(page)
+  await completeIDPage(page)
+}
+
+async function completeFundingInformationPage(page: Page) {
   const fundingInformationPage = await ApplyPage.initialize(page, 'Funding CAS-2 accommodation')
+
   await fundingInformationPage.checkRadio('Personal savings, salary or pension', true)
   await fundingInformationPage.checkRadioInGroup('Does the applicant have a National Insurance number?', 'Yes')
   await fundingInformationPage.checkRadioByTestId('receiving-benefits-radio-yes')
   await fundingInformationPage.checkRadioByTestId('received-benefit-sanctions-radio-yes')
+
   await fundingInformationPage.clickSave()
+}
+
+async function completeIDPage(page: Page) {
+  const idPage = await ApplyPage.initialize(page, 'What identity document (ID) does the applicant have?')
+
+  await idPage.checkCheckboxes(['Passport'])
+  await idPage.clickSave()
 }
 
 export const completeAreaInformationTask = async (page: Page, name: string) => {

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -52,7 +52,7 @@
       "receivedBenefitSanctions": "no"
     },
     "applicant-id": {
-      "idDocuments": ["passport", "travelPass", "birthCertificate", "bankOrDebitCard", "bankStatements", "drivingLicence", "wageSlip", "none"]
+      "idDocuments": ["passport", "travelPass", "birthCertificate", "bankOrDebitCard", "bankStatements", "drivingLicence", "wageSlip"]
     }
   },
   "solicitor-details": {

--- a/integration_tests/pages/apply/area-and-funding/funding-information/fundingCas2AccommodationPage.ts
+++ b/integration_tests/pages/apply/area-and-funding/funding-information/fundingCas2AccommodationPage.ts
@@ -14,12 +14,6 @@ export default class FundingCas2AccommodationPage extends ApplyPage {
     this.enterBenefitsDetails()
   }
 
-  completeWithHousingBenefits(): void {
-    this.selectFundingSource('benefits')
-    this.enterNationalInsuranceNumber()
-    this.enterBenefitsDetails()
-  }
-
   private selectFundingSource(fundingSource: FundingSources): void {
     this.checkRadioByNameAndValue('fundingSource', fundingSource)
   }

--- a/integration_tests/tests/apply/area-and-funding/funding-information/complete_funding_cas2_accommodation.cy.ts
+++ b/integration_tests/tests/apply/area-and-funding/funding-information/complete_funding_cas2_accommodation.cy.ts
@@ -4,19 +4,14 @@
 //    I want to confirm how the applicant is funding their CAS2 accommodation
 //    So that I can get the applicant into accommodation as quickly as possible with no FIEs
 //
-//  Scenario: When the applicant is using personal savings to fund the accommodation
+//  Scenario: continue to the next page
 //    Given I'm on the 'Funding CAS-2 Accommodation' question page
-//    When I select personal savings and give valid answers for all other questions
-//    Then I am taken to the task list page
-//
-//  Scenario: When the applicant is using house benefits to fund the accommodation
-//    Given I'm on the 'Funding CAS-2 Accommodation' question page
-//    When I select housing benefits and give valid answers for all other questions
+//    When I complete the form
+//    And I continue to the next page
 //    Then I am taken to the applicant ID page
 
 import FundingCas2AccommodationPage from '../../../../pages/apply/area-and-funding/funding-information/fundingCas2AccommodationPage'
 import Page from '../../../../pages/page'
-import TaskListPage from '../../../../pages/apply/taskListPage'
 import ApplicantIdPage from '../../../../pages/apply/area-and-funding/funding-information/applicantIdPage'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 
@@ -55,35 +50,19 @@ context('Visit "Confirm funding and ID" section', () => {
     Page.verifyOnPage(FundingCas2AccommodationPage, this.application)
   })
 
-  // Scenario: When the applicant is using personal savings to fund the accommodation
+  // Scenario: continue to the next page
   // ----------------------------
   it('continues to the task list page', function test() {
-    // Given I am on the Funding CAS-2 Accommodation
+    // Given I am on the Funding CAS-2 Accommodation question page
     const page = Page.verifyOnPage(FundingCas2AccommodationPage, this.application)
 
-    // When I complete the answers on the page
+    // When I complete the form
     page.completeWithPersonalSavings()
 
-    // And I click submit
+    // And I continue to the next page
     page.clickSubmit()
 
-    // I am taken to the task list page
-    Page.verifyOnPage(TaskListPage, this.application)
-  })
-
-  //  Scenario: When the applicant is using house benefits to fund the accommodation
-  // ----------------------------
-  it('continues to the applicant ID page', function test() {
-    // Given I am on the Funding CAS-2 Accommodation
-    const page = Page.verifyOnPage(FundingCas2AccommodationPage, this.application)
-
-    // When I complete the answers on the page
-    page.completeWithHousingBenefits()
-
-    // And I click submit
-    page.clickSubmit()
-
-    // I am taken to the applicant ID page
+    // Then I am taken to the applicant ID page
     Page.verifyOnPage(ApplicantIdPage, this.application)
   })
 })

--- a/server/form-pages/apply/area-and-funding/funding-information/fundingCas2Accommodation.test.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/fundingCas2Accommodation.test.ts
@@ -36,7 +36,6 @@ describe('FundingCas2Accommodation', () => {
     } as FundingCas2AccommodationBody)
   })
 
-  itShouldHaveNextValue(new FundingCas2Accommodation({ fundingSource: 'personalSavings' }, application), '')
   itShouldHaveNextValue(new FundingCas2Accommodation({ fundingSource: 'benefits' }, application), 'applicant-id')
   itShouldHavePreviousValue(new FundingCas2Accommodation({ fundingSource: 'personalSavings' }, application), 'taskList')
 

--- a/server/form-pages/apply/area-and-funding/funding-information/fundingCas2Accommodation.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/fundingCas2Accommodation.ts
@@ -59,9 +59,6 @@ export default class FundingCas2Accommodation implements TaskListPage {
   }
 
   next() {
-    if (this.body.fundingSource === 'personalSavings') {
-      return ''
-    }
     return 'applicant-id'
   }
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -272,19 +272,18 @@ describe('ApplicationService', () => {
         })
       })
 
-      it('deletes conditional data if required for funding information', async () => {
+      it('deletes conditional data if required for ID documents', async () => {
         page = createMock<TaskListPage>({
           errors: () => {
             return {} as TaskListErrors<TaskListPage>
           },
-          body: { fundingSource: 'personalSavings' },
+          body: { idDocuments: ['passport'] },
         })
-        ;(getPageName as jest.Mock).mockImplementation(() => 'funding-cas2-accommodation')
+        ;(getPageName as jest.Mock).mockImplementation(() => 'applicant-id')
         ;(getTaskName as jest.Mock).mockImplementation(() => 'funding-information')
 
         application.data = {
           'funding-information': {
-            'applicant-id': { question: 'answer' },
             'alternative-applicant-id': { question: 'answer' },
           },
         }
@@ -295,7 +294,7 @@ describe('ApplicationService', () => {
         expect(getApplicationUpdateData).toHaveBeenCalledWith({
           ...application,
           data: {
-            'funding-information': { 'funding-cas2-accommodation': { fundingSource: 'personalSavings' } },
+            'funding-information': { 'applicant-id': { idDocuments: ['passport'] } },
           },
         })
       })

--- a/server/utils/applications/deleteOrphanedData.test.ts
+++ b/server/utils/applications/deleteOrphanedData.test.ts
@@ -2,7 +2,7 @@ import deleteOrphanedFollowOnAnswers from './deleteOrphanedData'
 
 describe('deleteOrphanedFollowOnAnswers', () => {
   describe('funding-information', () => {
-    describe('when fundingSource is personalSavings', () => {
+    describe('when applicant ID is not "None"', () => {
       const applicationData = {
         'funding-information': {
           'funding-cas2-accommodation': {
@@ -17,37 +17,11 @@ describe('deleteOrphanedFollowOnAnswers', () => {
         },
       }
 
-      it('removes identification and alternative-identification data', () => {
-        expect(deleteOrphanedFollowOnAnswers(applicationData)).toEqual({
-          'funding-information': {
-            'funding-cas2-accommodation': {
-              fundingSource: 'personalSavings',
-            },
-          },
-        })
-      })
-    })
-
-    describe('when fundingSource is benefits and applicant ID is not "None"', () => {
-      const applicationData = {
-        'funding-information': {
-          'funding-cas2-accommodation': {
-            fundingSource: 'benefits',
-          },
-          'applicant-id': {
-            idDocuments: 'passport',
-          },
-          'alternative-applicant-id': {
-            alternativeIDDocuments: 'citizenCard',
-          },
-        },
-      }
-
       it('removes alternative-identification data', () => {
         expect(deleteOrphanedFollowOnAnswers(applicationData)).toEqual({
           'funding-information': {
             'funding-cas2-accommodation': {
-              fundingSource: 'benefits',
+              fundingSource: 'personalSavings',
             },
             'applicant-id': {
               idDocuments: 'passport',

--- a/server/utils/applications/deleteOrphanedData.ts
+++ b/server/utils/applications/deleteOrphanedData.ts
@@ -4,11 +4,6 @@ import { lastKnownKeys, previousKeys } from '../../form-pages/apply/about-the-pe
 import { PreviousConvictionsAnswers } from '../../form-pages/apply/offence-information/offending-history/anyPreviousConvictions'
 
 export default function deleteOrphanedFollowOnAnswers(applicationData: Unit): Unit {
-  const deleteOrphanedFundingInformation = () => {
-    delete applicationData['funding-information']['applicant-id']
-    delete applicationData['funding-information']['alternative-applicant-id']
-  }
-
   const deleteOrphanedFundingAlternativeIdInformation = () => {
     delete applicationData['funding-information']['alternative-applicant-id']
   }
@@ -53,21 +48,8 @@ export default function deleteOrphanedFollowOnAnswers(applicationData: Unit): Un
     return applicationData[taskName]?.[pageName]?.[questionKey] === answerToCheck
   }
 
-  if (
-    hasOrphanedInformation({
-      taskName: 'funding-information',
-      pageName: 'funding-cas2-accommodation',
-      questionKey: 'fundingSource',
-      answerToCheck: 'personalSavings',
-    })
-  ) {
-    deleteOrphanedFundingInformation()
-  }
-
-  if (
-    applicationData['funding-information']?.['funding-cas2-accommodation']?.fundingSource === 'benefits' &&
-    applicationData['funding-information']?.['applicant-id']?.idDocuments !== 'none'
-  ) {
+  const idDocs = applicationData['funding-information']?.['applicant-id']?.idDocuments
+  if (idDocs && idDocs !== 'none') {
     deleteOrphanedFundingAlternativeIdInformation()
   }
 

--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -479,7 +479,7 @@ describe('checkYourAnswersUtils', () => {
       expect(
         arrayAnswersAsString(application, questions, 'funding-information', 'applicant-id', 'idDocuments'),
       ).toEqual(
-        'Passport,Travel pass with photograph,Birth certificate,Bank account or debit card,Bank, building society or Post Office card account statements,UK photo driving licence (full or provisional),Recent wage slip (with payee name and NI number),None of these options',
+        'Passport,Travel pass with photograph,Birth certificate,Bank account or debit card,Bank, building society or Post Office card account statements,UK photo driving licence (full or provisional),Recent wage slip (with payee name and NI number)',
       )
     })
   })


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-306

# Changes in this PR

Nacro want to know what types of ID applicants have regardless of whether they are using personal savings or benefits to pay for their place, so we are updating the funding source page to always send them on to the ID page.

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
