### PR TITLE
Move sqs-hmpps-audit-secret to individual namespaces

### DIFF
--- a/helm_deploy/hmpps-community-accommodation-tier-2-bail-ui/values.yaml
+++ b/helm_deploy/hmpps-community-accommodation-tier-2-bail-ui/values.yaml
@@ -55,9 +55,6 @@ generic-service:
       REDIS_AUTH_TOKEN: 'auth_token'
     application-insights:
       APPINSIGHTS_INSTRUMENTATIONKEY: 'APPINSIGHTS_INSTRUMENTATIONKEY'
-    sqs-hmpps-audit-secret:
-     AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
-     AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
 
   allowlist:
     groups:

--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -17,6 +17,11 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     ENVIRONMENT_NAME: DEV
 
+  namespace_secrets:
+    sqs-hmpps-audit-secret:
+     AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
+     AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
+
   allowlist: null
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,5 +17,10 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     ENVIRONMENT_NAME: PRE-PRODUCTION
 
+  namespace_secrets:
+    sqs-hmpps-audit-secret:
+     AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
+     AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
+
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -14,5 +14,10 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
 
+  namespace_secrets:
+    sqs-hmpps-audit-secret:
+     AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
+     AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
+
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises


### PR DESCRIPTION
# Context
As this secret is not set in the test environment, deployments to test were failing with the error: secret "sqs-hmpps-audit-secret" not found.

We don't require audit logs in the test environment, so moving this secret to individual namespaces ensures test environment will not try to retrieve it.

In application code, the call to AWS SQS will silently fail, as logErrors is set to false by default[1].

[1]
https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui/blob/f943f18755b4c742d2ea8da48f0e04a0c1450fbe/server/services/auditService.ts#L44

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
