### PR TITLE
Ensure bail hearing date is returned from page response

### DIFF
--- a/server/form-pages/apply/bail-information/bail-hearing-information/bailHearingDate.test.ts
+++ b/server/form-pages/apply/bail-information/bail-hearing-information/bailHearingDate.test.ts
@@ -11,7 +11,6 @@ describe('BailHearingDate', () => {
   describe('response', () => {
     describe('when a date is provided', () => {
       const body: BailHearingDateBody = {
-        bailHearingDate: '2024-03-27',
         'bailHearingDate-month': '10',
         'bailHearingDate-year': '2023',
         'bailHearingDate-day': '01',
@@ -27,7 +26,6 @@ describe('BailHearingDate', () => {
 
     describe('when a date is not provided', () => {
       const body: BailHearingDateBody = {
-        bailHearingDate: '',
         'bailHearingDate-month': '',
         'bailHearingDate-year': '',
         'bailHearingDate-day': '',

--- a/server/form-pages/apply/bail-information/bail-hearing-information/bailHearingDate.ts
+++ b/server/form-pages/apply/bail-information/bail-hearing-information/bailHearingDate.ts
@@ -5,7 +5,7 @@ import TaskListPage from '../../../taskListPage'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { getQuestions } from '../../../utils/questions'
 import { dateBodyProperties } from '../../../utils'
-import { DateFormats } from '../../../../utils/dateUtils'
+import { dateAndTimeInputsAreValidDates, DateFormats } from '../../../../utils/dateUtils'
 
 export type BailHearingDateBody = ObjectWithDateParts<'bailHearingDate'>
 
@@ -49,7 +49,7 @@ export default class BailHearingDate implements TaskListPage {
 
   response() {
     return {
-      [this.questions.bailHearingDate.question]: this.body.bailHearingDate
+      [this.questions.bailHearingDate.question]: dateAndTimeInputsAreValidDates(this.body, 'bailHearingDate')
         ? DateFormats.dateAndTimeInputsToUiDate(this.body, 'bailHearingDate')
         : '',
     }


### PR DESCRIPTION
On some of our pages with dates, the error validation is having the unintended side effect of generating an ISO string on the page body. We don’t have any validation on the bail hearing date page, so that’s not happening here. This is something we will need to revisit, but for now, we return the formatted date from the response method if there are valid date parts in the body, or else we return an empty string.

# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-445

# Changes in this PR

## Screenshots of UI changes

### Before

![Screenshot 2025-04-04 at 14 35 34](https://github.com/user-attachments/assets/adc19b32-f4a3-4170-aa64-f8149b62604b)

### After

![Screenshot 2025-04-04 at 14 35 11](https://github.com/user-attachments/assets/cb39d9fc-3655-4d5c-bd81-d8e87870c2f6)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
