### PR TITLE
Enable prod deployment pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -97,13 +97,13 @@ jobs:
     with:
       environment: 'preprod'
       app_version: '${{ needs.build.outputs.app_version }}'
-  # deploy_prod:
-  #   name: Deploy to production environment
-  #   needs: 
-  #     - build
-  #     - deploy_preprod
-  #   uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v1 # WORKFLOW_VERSION
-  #   secrets: inherit
-  #   with:
-  #     environment: 'prod'
-  #     app_version: '${{ needs.build.outputs.app_version }}'
+  deploy_prod:
+    name: Deploy to production environment
+    needs: 
+      - build
+      - deploy_preprod
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
+    secrets: inherit
+    with:
+      environment: 'prod'
+      app_version: '${{ needs.build.outputs.app_version }}'


### PR DESCRIPTION
Enabling prod deployments

Cloud platform config PR - https://github.com/ministryofjustice/cloud-platform-environments/pull/31494

System client request - https://dsdmoj.atlassian.net/browse/HAAR-3848

MFA request - https://mojdt.slack.com/archives/C02S71KUBED/p1744022395777419

We can use `kubectl -n hmpps-community-accommodation-prod get events` to debug if required, and if successfully deployed @adamhughes86 has prod access to login and smoke test