### PR TITLE
Fix - write bail hearing date as primary field on application

### DIFF
--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -22,6 +22,7 @@ describe('getApplicationSubmissionData', () => {
       translatedDocument: mockApplication.document,
       preferredAreas: 'London | Birmingham',
       telephoneNumber: '1234567',
+      bailHearingDate: '2025-02-02',
     })
   })
 })

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -1,6 +1,10 @@
 import { Cas2v2Application as Application, SubmitCas2v2Application, UpdateApplication } from '@approved-premises/api'
 
-import { preferredAreasFromAppData, telephoneNumberFromAppData } from './managementInfoFromAppData'
+import {
+  preferredAreasFromAppData,
+  telephoneNumberFromAppData,
+  bailHearingDateFromAppData,
+} from './managementInfoFromAppData'
 
 export const getApplicationUpdateData = (application: Application): UpdateApplication => {
   return {
@@ -16,5 +20,6 @@ export const getApplicationSubmissionData = (application: Application): SubmitCa
     applicationOrigin: application.applicationOrigin,
     preferredAreas: preferredAreasFromAppData(application),
     telephoneNumber: telephoneNumberFromAppData(application),
+    bailHearingDate: bailHearingDateFromAppData(application),
   }
 }

--- a/server/utils/applications/managementInfoFromAppData.test.ts
+++ b/server/utils/applications/managementInfoFromAppData.test.ts
@@ -1,4 +1,8 @@
-import { preferredAreasFromAppData, telephoneNumberFromAppData } from './managementInfoFromAppData'
+import {
+  preferredAreasFromAppData,
+  telephoneNumberFromAppData,
+  bailHearingDateFromAppData,
+} from './managementInfoFromAppData'
 
 import { applicationFactory } from '../../testutils/factories'
 
@@ -84,6 +88,41 @@ describe('managementInfoFromAppData', () => {
         data,
       })
       expect(telephoneNumberFromAppData(application)).toEqual(null)
+    })
+  })
+
+  describe('bailHearingDateFromAppData', () => {
+    it('returns the bail hearing date as an ISO string', () => {
+      const application = applicationFactory.build({
+        data: {
+          'bail-hearing-information': {
+            'bail-hearing-date': {
+              'bailHearingDate-year': '2025',
+              'bailHearingDate-month': '2',
+              'bailHearingDate-day': '2',
+            },
+          },
+        },
+      })
+      expect(bailHearingDateFromAppData(application)).toEqual('2025-02-02')
+    })
+
+    const noDateData = [
+      {
+        'bail-hearing-information': null,
+      },
+      {
+        'bail-hearing-information': { 'bail-hearing-date': null },
+      },
+      {},
+      null,
+    ]
+
+    it.each(noDateData)('returns null if no contact number is given', data => {
+      const application = applicationFactory.build({
+        data,
+      })
+      expect(bailHearingDateFromAppData(application)).toEqual(null)
     })
   })
 })

--- a/server/utils/applications/managementInfoFromAppData.ts
+++ b/server/utils/applications/managementInfoFromAppData.ts
@@ -1,4 +1,6 @@
 import { Cas2v2Application as Application } from '@approved-premises/api'
+import { ObjectWithDateParts } from '@approved-premises/ui'
+import { dateAndTimeInputsAreValidDates, DateFormats } from '../dateUtils'
 
 const preferredAreasFromAppData = (application: Application): string => {
   // @ts-expect-error Requires refactor to satisfy TS7053
@@ -23,4 +25,17 @@ const telephoneNumberFromAppData = (application: Application): string | null => 
   return telephoneNumber || null
 }
 
-export { preferredAreasFromAppData, telephoneNumberFromAppData }
+const bailHearingDateFromAppData = (application: Application): string | null => {
+  // @ts-expect-error Requires refactor to satisfy TS7053
+  const bailHearingDateObj: ObjectWithDateParts<'bailHearingDate'> = (application.data as Record<string, unknown>)?.[
+    'bail-hearing-information'
+  ]?.['bail-hearing-date']
+
+  if (dateAndTimeInputsAreValidDates(bailHearingDateObj, 'bailHearingDate')) {
+    return DateFormats.dateAndTimeInputsToIsoString(bailHearingDateObj, 'bailHearingDate').bailHearingDate
+  }
+
+  return null
+}
+
+export { preferredAreasFromAppData, telephoneNumberFromAppData, bailHearingDateFromAppData }


### PR DESCRIPTION
# Context

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Ensures bail hearing date is added to application as a primary field on submission.

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
