### PR TITLE
Removing allowlist overrides as they're all the same

### DIFF
--- a/helm_deploy/hmpps-community-accommodation-tier-2-bail-ui/values.yaml
+++ b/helm_deploy/hmpps-community-accommodation-tier-2-bail-ui/values.yaml
@@ -57,9 +57,7 @@ generic-service:
     application-insights:
       APPINSIGHTS_INSTRUMENTATIONKEY: 'APPINSIGHTS_INSTRUMENTATIONKEY'
 
-  allowlist:
-    groups:
-      - internal
+  allowlist: null
 
 generic-prometheus-alerts:
   targetApplication: hmpps-community-accommodation-tier-2-bail-ui

--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -22,7 +22,5 @@ generic-service:
      AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
      AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
 
-  allowlist: null
-
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -22,7 +22,5 @@ generic-service:
      AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
      AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
 
-  allowlist: null
-
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -22,7 +22,5 @@ generic-service:
      AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
      AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
 
-  allowlist: null
-
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -17,7 +17,5 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     ENVIRONMENT_NAME: TEST
 
-  allowlist: null
-
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises


### PR DESCRIPTION
There is a [build issue](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui/actions/runs/14334505350/job/40179161865) that is preventing deployments to dev. The error is:

`coalesce.go:298: warning: cannot overwrite table with non table for hmpps-community-accommodation-tier-2-bail-ui.generic-service.allowlist (map[groups:[internal]])`

I've set the default allowlist to null as all of our environments are using the same allowlist. I will test the deployment after this goes through
