### PR TITLE
feat: show crn/noms number dependant on app origin

### DIFF
--- a/server/form-pages/apply/check-your-answers/check-your-answers/checkYourAnswers.test.ts
+++ b/server/form-pages/apply/check-your-answers/check-your-answers/checkYourAnswers.test.ts
@@ -39,6 +39,8 @@ describe('CheckYourAnswers', () => {
       expect(page.applicationSummary()).toEqual({
         id: application.id,
         name: person.name,
+        applicationOrigin: application.applicationOrigin,
+        crn: person.crn,
         prisonNumber: person.nomsNumber,
         prisonName: person.prisonName,
         referrerName: application.createdBy.name,
@@ -59,6 +61,8 @@ describe('CheckYourAnswers', () => {
 
         expect(page.applicationSummary()).toEqual({
           id: application.id,
+          applicationOrigin: application.applicationOrigin,
+          crn: null,
           name: null,
           prisonNumber: null,
           prisonName: null,

--- a/server/form-pages/apply/check-your-answers/check-your-answers/checkYourAnswers.ts
+++ b/server/form-pages/apply/check-your-answers/check-your-answers/checkYourAnswers.ts
@@ -17,6 +17,8 @@ type ApplicationSummary = {
   referrerName: string
   contactEmail?: string
   view: string
+  applicationOrigin: string
+  crn: string
 }
 
 @Page({ name: 'check-your-answers', bodyProperties: ['checkYourAnswers'] })
@@ -46,6 +48,8 @@ export default class CheckYourAnswers implements TaskListPage {
       prisonName: isFullPerson(this.application.person) ? this.application.person.prisonName : null,
       referrerName: this.application.createdBy.name,
       contactEmail: this.application.createdBy.email,
+      applicationOrigin: this.application.applicationOrigin,
+      crn: isFullPerson(this.application.person) ? this.application.person.crn : null,
       view: 'checkYourAnswers',
     }
   }

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -25,6 +25,8 @@
       {{ applicationSummary({
         id: application.id,
         name: application.person.name,
+        applicationOrigin: application.applicationOrigin,
+        crn: application.person.crn,
         prisonNumber: application.person.nomsNumber,
         prisonName: application.person.prisonName,
         referrerName: application.createdBy.name,

--- a/server/views/assess/applications/show.njk
+++ b/server/views/assess/applications/show.njk
@@ -29,6 +29,8 @@
       {{ applicationSummary({
         id: application.id,
         name: application.person.name,
+        applicationOrigin: application.applicationOrigin,
+        crn: application.person.crn,
         prisonNumber: application.person.nomsNumber,
         prisonName: application.person.prisonName,
         referrerName: application.submittedBy.name,

--- a/server/views/components/applicationSummary/macro.njk
+++ b/server/views/components/applicationSummary/macro.njk
@@ -11,11 +11,12 @@
         {{ summary.name }}'s application
         {% endif %}
       <br>
-      <span class="govuk-body-l submitted-application-panel__text">
-        <strong>Prison number:</strong>
-        {{ summary.prisonNumber }}</span>
+      {% if (summary.applicationOrigin == "courtBail") %}
+        <span class="govuk-body-l submitted-application-panel__text"><strong>CRN:</strong>{{ summary.crn }}</span>
+      {% else %}
+        <span class="govuk-body-l submitted-application-panel__text"><strong>Prison number:</strong>{{ summary.prisonNumber }}</span>
+      {% endif %}
     </h1>
-
     <ul class="govuk-list govuk-list--spaced submitted-application-panel__text">
       <li>
         <span class="govuk-!-font-weight-bold">Referrer name: </span>{{ summary.referrerName }}


### PR DESCRIPTION
# Context

1. https://dsdmoj.atlassian.net/browse/CBA-455
2. https://dsdmoj.atlassian.net/browse/CBA-457
3. https://dsdmoj.atlassian.net/browse/CBA-454

# Changes in this PR

Switches CRN/Prison number on what the app origin is

## Screenshots of UI changes

### Before

<img width="1171" alt="Screenshot 2025-04-09 at 11 28 22" src="https://github.com/user-attachments/assets/43263927-4112-4713-878b-dc9c50f29845" />

### After

<img width="1179" alt="Screenshot 2025-04-09 at 11 27 23" src="https://github.com/user-attachments/assets/d13f475f-0267-46e9-9220-4caf1fe77e93" />

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [x] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
