### PR TITLE
Update dev environment name value to lowercase

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -15,7 +15,7 @@ generic-service:
     APPROVED_PREMISES_API_URL: "https://approved-premises-api-dev.hmpps.service.justice.gov.uk"
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
-    ENVIRONMENT_NAME: DEV
+    ENVIRONMENT_NAME: dev
 
   namespace_secrets:
     sqs-hmpps-audit-secret:


### PR DESCRIPTION
To make our environment variables consistent with the other CAS projects we are changing the dev environment name to lowercase

Once this has deployed @adamhughes86 will test and fire an event to sentry