### PR TITLE
Updating environment variables

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,7 +15,7 @@ generic-service:
     APPROVED_PREMISES_API_URL: "https://approved-premises-api-preprod.hmpps.service.justice.gov.uk"
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
-    ENVIRONMENT_NAME: PRE-PRODUCTION
+    ENVIRONMENT_NAME: preprod
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,7 +15,7 @@ generic-service:
     APPROVED_PREMISES_API_URL: "https://approved-premises-api.hmpps.service.justice.gov.uk"
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
-    ENVIRONMENT_NAME: PRODUCTION
+    ENVIRONMENT_NAME: prod
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -15,7 +15,7 @@ generic-service:
     APPROVED_PREMISES_API_URL: "https://approved-premises-api-test.hmpps.service.justice.gov.uk"
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
-    ENVIRONMENT_NAME: TEST
+    ENVIRONMENT_NAME: test
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises

--- a/server/middleware/setUpSentry.ts
+++ b/server/middleware/setUpSentry.ts
@@ -29,7 +29,7 @@ export function setUpSentryRequestHandler(app: express.Express): void {
           return 0
         }
 
-        if (config.environmentName === 'PROD') {
+        if (config.environmentName === 'prod') {
           return 1
         }
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -38,7 +38,7 @@ export default function nunjucksSetup(app: express.Express): void {
 
   app.locals.applicationName = 'Short-Term Accommodation (CAS2) for bail'
   app.locals.environmentName = config.environmentName
-  app.locals.environmentNameColour = config.environmentName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
+  app.locals.environmentNameColour = config.environmentName === 'preprod' ? 'govuk-tag--green' : ''
   let assetManifest: Record<string, string> = {}
 
   try {


### PR DESCRIPTION
To have consistency with the wider CAS team we're renaming the environment variables

@adamhughes86 will test in the environments once deployed, create a new Sentry project to clear old environments, and then push test events to sentry