### PR TITLE
feat: update text on ACCT page

### DIFF
--- a/integration_tests/pages/apply/risks-and-needs/risk-information/acctPage.ts
+++ b/integration_tests/pages/apply/risks-and-needs/risk-information/acctPage.ts
@@ -6,7 +6,7 @@ import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 export default class AcctPage extends ApplyPage {
   constructor(private readonly application: Application) {
     super(
-      `${nameOrPlaceholderCopy(application.person, 'The person')}'s ACCT notes`,
+      `Assessment, Care in Custody and Teamwork (ACCT) notes for ${nameOrPlaceholderCopy(application.person, 'The person')}`,
       application,
       'risk-information',
       'acct',

--- a/server/form-pages/apply/risks-and-needs/risk-information/acct.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-information/acct.test.ts
@@ -9,7 +9,7 @@ describe('Acct', () => {
     it('personalises the page title', () => {
       const page = new Acct({}, application)
 
-      expect(page.title).toEqual("Roger Smith's ACCT notes")
+      expect(page.title).toEqual('Assessment, Care in Custody and Teamwork (ACCT) notes for Roger Smith')
     })
   })
 

--- a/server/form-pages/apply/risks-and-needs/risk-information/acct.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-information/acct.ts
@@ -24,7 +24,7 @@ type AcctUI = {
 export default class Acct implements TaskListPage {
   documentTitle = "The person's ACCT notes"
 
-  title = `${nameOrPlaceholderCopy(this.application.person)}'s ACCT notes`
+  title = `Assessment, Care in Custody and Teamwork (ACCT) notes for ${nameOrPlaceholderCopy(this.application.person)}`
 
   body: AcctBody
 

--- a/server/form-pages/apply/risks-and-needs/risk-information/acct.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-information/acct.ts
@@ -22,7 +22,7 @@ type AcctUI = {
   bodyProperties: ['acctDetail'],
 })
 export default class Acct implements TaskListPage {
-  documentTitle = "The person's ACCT notes"
+  documentTitle = 'Assessment, Care in Custody and Teamwork (ACCT) notes for the person'
 
   title = `Assessment, Care in Custody and Teamwork (ACCT) notes for ${nameOrPlaceholderCopy(this.application.person)}`
 

--- a/server/views/applications/pages/risk-information/_risk-information-screen.njk
+++ b/server/views/applications/pages/risk-information/_risk-information-screen.njk
@@ -23,7 +23,7 @@
             href: paths.applications.pages.show({ id: applicationId, task: 'risk-information', page: 'self-harm' }),
             active: (pageName === 'self-harm')
           }, {
-            text: 'ACCT',
+            text: 'ACCT notes',
             href: paths.applications.pages.show({ id: applicationId, task: 'risk-information', page: 'acct' }),
             active: (pageName === 'acct')
           }, {

--- a/server/views/applications/pages/risk-information/acct.njk
+++ b/server/views/applications/pages/risk-information/acct.njk
@@ -1,10 +1,19 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% extends "./_risk-information-screen.njk" %}
 {% set pageName = "acct" %}
 
 {% block questions %}
-  <p class="govuk-body">An Assessment, Care in Custody and Teamwork (ACCT) is a tailored plan to 
-  support someone in prison at risk of self harm or suicide.</p>
+
+  {% call govukInsetText({
+    classes: "guidance-panel"
+  }) %}
+  <p class="govuk-body">An ACCT is a tailored plan to support someone in prison at risk of self harm or suicide.</p>
+
+  <p class="govuk-body">
+    If the applicant does not have an ACCT note or is not in prison custody, you can skip this question by selecting &quot;Save and Continue&quot;.
+  </p>
+  {%  endcall %}
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CBA-368

# Changes in this PR

Add a line of content to page explaining that user can click through if no ACCT done. This would be using a small content change to avoid having to build a new yes/no screen for the ACCT pages. 

## Screenshots of UI changes

### Before

![Untitled](https://github.com/user-attachments/assets/ef058de6-3566-4836-965f-cca17c421cb7)

### After

![Screenshot 2025-04-09 at 15 06 09](https://github.com/user-attachments/assets/40928fe8-3400-45ee-8e8a-24dbca8dca62)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [x] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
