### PR TITLE
Fix E2E test

### DIFF
--- a/e2e-tests/steps/assess.ts
+++ b/e2e-tests/steps/assess.ts
@@ -20,7 +20,7 @@ export const viewSubmittedApplication = async (page: Page) => {
   await page.getByTestId('submitted-applications').getByRole('link').first().click()
   await page.getByRole('button', { name: 'View submitted application' }).click()
   await expect(page.locator('h1')).toContainText(`application`)
-  await expect(page.locator('h2').first()).toContainText('Applicant details')
+  await expect(page.getByTestId('applicant-details-card')).toContainText('Applicant details')
 }
 
 export const addNote = async (page: Page) => {

--- a/server/views/partials/applicantDetails.njk
+++ b/server/views/partials/applicantDetails.njk
@@ -9,6 +9,9 @@
           card: {
             title: {
               text: "Applicant details"
+            },
+            attributes: {
+              "data-testid": "applicant-details-card"
             }
           },
           rows: getApplicantDetails(application)


### PR DESCRIPTION
A recent accessibility fix to heading structure was causing this test to fail, because ‘Applicant details’ was no longer the first h2 element. I’ve replaced that with a test id locator to make the test more resilient.

# Context

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
