### PR TITLE
fix: adds optional to bail hearing pages

### DIFF
--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -992,7 +992,7 @@ export const getQuestions = (name: string) => {
     'bail-hearing-information': {
       'court-name': {
         courtName: {
-          question: `What's the name of the court where ${name}'s bail hearing will take place?`,
+          question: `What's the name of the court where ${name}'s bail hearing will take place? (optional)`,
         },
       },
       'bail-hearing-date': {
@@ -1003,7 +1003,7 @@ export const getQuestions = (name: string) => {
       },
       'bail-hearing-medium': {
         bailHearingMedium: {
-          question: `How will ${name}'s bail hearing be heard?`,
+          question: `How will ${name}'s bail hearing be heard? (optional)`,
           answers: {
             inCourt: 'In court',
             videoLink: 'Video link',


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CBA-233

# Changes in this PR

Two of the questions around bail hearing details do not have validation because court users may not know the answers to them. This means they are not mandatory and should be marked as optional, so we need to add (optional) in lowercase to the end of the questions. 

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
