### PR TITLE
[CBA-541] Ensure correct safeguarding answer is displayed

### DIFF
--- a/server/form-pages/apply/offence-information/previous-unspent-convictions/unspentConvictions.test.ts
+++ b/server/form-pages/apply/offence-information/previous-unspent-convictions/unspentConvictions.test.ts
@@ -21,6 +21,13 @@ describe('UnspentConvictions', () => {
             convictionType: 'arson',
             numberOfConvictions: '2',
             currentlyServing: 'no',
+            safeguarding: 'dontKnow',
+            safeguardingDetail: '',
+          },
+          {
+            convictionType: 'drugs',
+            numberOfConvictions: '2',
+            currentlyServing: 'no',
             safeguarding: 'no',
             safeguardingDetail: '',
           },
@@ -58,8 +65,17 @@ describe('UnspentConvictions', () => {
             convictionTypeText: 'Arson',
             numberOfConvictions: '2',
             currentlyServing: 'No',
-            safeguarding: 'No',
+            safeguarding: 'Not known',
             removeLink: `/applications/${applicationWithData.id}/tasks/previous-unspent-convictions/pages/unspent-convictions-data/1/removeFromList?redirectPage=unspent-convictions`,
+          },
+          {
+            convictionTypeTag:
+              '<strong class="govuk-tag govuk-tag--custom-brown">Drugs</strong><p class="govuk-visually-hidden">conviction information</p>',
+            convictionTypeText: 'Drugs',
+            numberOfConvictions: '2',
+            currentlyServing: 'No',
+            safeguarding: 'No',
+            removeLink: `/applications/${applicationWithData.id}/tasks/previous-unspent-convictions/pages/unspent-convictions-data/2/removeFromList?redirectPage=unspent-convictions`,
           },
         ])
       })
@@ -84,6 +100,8 @@ describe('UnspentConvictions', () => {
           '<strong class="govuk-tag govuk-tag--blue">Stalking or Harassment</strong><p class="govuk-visually-hidden">conviction information</p>':
             'Number of convictions: 3\r\nActive sentence: Yes\r\nSafeguarding: Safeguarding detail',
           '<strong class="govuk-tag govuk-tag--yellow">Arson</strong><p class="govuk-visually-hidden">conviction information</p>':
+            'Number of convictions: 2\r\nActive sentence: No\r\nSafeguarding: Not known',
+          '<strong class="govuk-tag govuk-tag--custom-brown">Drugs</strong><p class="govuk-visually-hidden">conviction information</p>':
             'Number of convictions: 2\r\nActive sentence: No\r\nSafeguarding: No',
         })
       })

--- a/server/form-pages/apply/offence-information/previous-unspent-convictions/unspentConvictions.ts
+++ b/server/form-pages/apply/offence-information/previous-unspent-convictions/unspentConvictions.ts
@@ -61,7 +61,7 @@ export default class UnspentConvictions implements TaskListPage {
           convictionTypeText,
           numberOfConvictions: unspentConviction.numberOfConvictions,
           currentlyServing: this.getCurrentlyServingAnswer(unspentConviction.currentlyServing),
-          safeguarding: unspentConviction.safeguardingDetail || 'No',
+          safeguarding: this.getSafeguardingAnswer(unspentConviction),
           removeLink: `${paths.applications.removeFromList({
             id: application.id,
             task: this.taskName,
@@ -145,5 +145,17 @@ export default class UnspentConvictions implements TaskListPage {
     }
 
     return 'No'
+  }
+
+  getSafeguardingAnswer(unspentConviction: UnspentConvictionsDataBody) {
+    if (unspentConviction.safeguardingDetail) {
+      return unspentConviction.safeguardingDetail
+    }
+
+    if (unspentConviction.safeguarding === 'no') {
+      return 'No'
+    }
+
+    return 'Not known'
   }
 }


### PR DESCRIPTION
[JIRA](https://dsdmoj.atlassian.net/browse/CBA-541?atlOrigin=eyJpIjoiZTNkMjg1ZGNiMDE1NGFmZDljOGRlNWMxZmE0MzIwOTYiLCJwIjoiaiJ9)

# Context
This fixes a bug when the safeguarding answer is "don't know", but instead displayed "No" when displaying the safeguarding answer.

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Screenshot
<img width="659" alt="Screenshot 2025-04-14 at 13 41 21" src="https://github.com/user-attachments/assets/f8b3ae31-9ea0-4eee-8f09-c15d6ea1f7eb" />

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
