### PR TITLE
Fix previous page key for alleged offences data

### DIFF
--- a/server/form-pages/apply/offence-information/alleged-offences/custom-forms/allegedOffenceData.test.ts
+++ b/server/form-pages/apply/offence-information/alleged-offences/custom-forms/allegedOffenceData.test.ts
@@ -23,7 +23,7 @@ describe('AllegedOffenceData', () => {
   })
 
   itShouldHaveNextValue(new AllegedOffenceData({}, application), 'alleged-offences')
-  itShouldHavePreviousValue(new AllegedOffenceData({}, application), 'alleged-offences')
+  itShouldHavePreviousValue(new AllegedOffenceData({}, application), 'taskList')
 
   describe('errors', () => {
     describe('when there are no errors', () => {

--- a/server/form-pages/apply/offence-information/alleged-offences/custom-forms/allegedOffenceData.ts
+++ b/server/form-pages/apply/offence-information/alleged-offences/custom-forms/allegedOffenceData.ts
@@ -46,7 +46,7 @@ export default class AllegedOffenceData implements TaskListPage {
   }
 
   previous() {
-    return 'alleged-offences'
+    return 'taskList'
   }
 
   next() {


### PR DESCRIPTION
[JIRA](https://dsdmoj.atlassian.net/browse/CBA-504?atlOrigin=eyJpIjoiMDY3Y2MyZmRlZGYwNDMzZGIzZDA0MGE0ZjdhZTFmNjUiLCJwIjoiaiJ9)

# Context
When a page is the first in a task, the previous value should be 'taskList' so that the back button works as it's supposed to.

This change fixes a bug that could potentially trap a referrer when opening the alleged offences task for the first time.

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
