### PR TITLE
Reinstate integration test setup

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,14 @@
+version: '3.1'
+services:
+ 
+  wiremock:
+    image: wiremock/wiremock
+    networks:
+    - hmpps_int
+    container_name: wiremock_test
+    restart: always
+    ports:
+      - "9999:8080"
+ 
+networks:
+   hmpps_int:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start:dev": "concurrently -k -p \"[{name}]\" -n \"ESBuild,Node\" -c \"yellow.bold,cyan.bold\" \"node esbuild-configs/esbuild.config.js --build --watch\" \"node esbuild-configs/esbuild.config.js --dev-server\"",
     "start-feature": " node $NODE_DEBUG_OPTION --env-file=feature.env dist/server.js | bunyan -o short",
     "start-feature:dev": "concurrently -k -p \"[{name}]\" -n \"ESBuild,Node\" -c \"yellow.bold,cyan.bold\" \"node esbuild-configs/esbuild.config.js  --build --watch \" \"node esbuild-configs/esbuild.config.js --dev-test-server\"",
+    "start-test-wiremock": "docker-compose -f docker-compose-test.yml up -d",
     "lint": "eslint . --cache --max-warnings 0",
     "lint-fix": "eslint . --cache --max-warnings 0 --fix",
     "typecheck": "tsc && tsc -p integration_tests",


### PR DESCRIPTION
This script and docker compose file were removed as part of the ap-tools/E2E test changes, but they are needed to run our integration tests locally.

# Context

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
