### PR TITLE
Require e2e tests to pass for preprod deployment

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -92,6 +92,7 @@ jobs:
     needs: 
       - build
       - deploy_dev
+      - node_e2e_tests
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
     secrets: inherit
     with:


### PR DESCRIPTION
[JIRA](https://dsdmoj.atlassian.net/browse/CBA-551?atlOrigin=eyJpIjoiZmM4ZDY5ZmE0YjlhNDQxODkxMzgwMDk0MGVkMjYwZTAiLCJwIjoiaiJ9)

# Context
Previously this was non-blocking as CAS2 Bail hadn't launched into private beta. As this is now live code, these tests will be required to pass before deploying to preprod, bringing it in line with the other UIs.

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
