### PR TITLE
CBA-367 - information sources - fix CYA view

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -210,7 +210,8 @@
       "otherHealthNeeds": "no"
     },
     "information-sources": {
-      "informationSources": ["nomis", "casework"]
+      "informationSources": ["nomis", "casework"],
+      "otherSourcesDetail": "Another source"
     }
   },
   "risk-information": {
@@ -283,7 +284,8 @@
       }
     ],
     "information-sources": {
-      "informationSources": ["nomis", "casework"]
+      "informationSources": ["nomis", "casework"],
+      "otherSourcesDetail": "Another source"
     }
   },
   "add-probation-supervision-details": {

--- a/server/form-pages/apply/risks-and-needs/health-needs/informationSources.test.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/informationSources.test.ts
@@ -45,4 +45,37 @@ describe('InformationSources', () => {
       })
     })
   })
+
+  describe('response', () => {
+    it('returns formatted data', () => {
+      const body: Partial<InformationSourcesBody> = {
+        informationSources: ['interview', 'police', 'casework', 'healthcare', 'ndelius', 'nomis', 'oasys', 'other'],
+        otherSourcesDetail: 'some other sources',
+      }
+
+      const page = new InformationSources(body, application)
+
+      expect(page.response()).toEqual({
+        "Where did you get the information on the applicant's health needs from?":
+          'In person interview with applicant\r\nPolice and Safeguarding teams\r\nCase work\r\nHealthcare teams\r\nNDelius (National probation database)\r\nNOMIS (National Offender Management Information System)\r\nPrevious or current OASys\r\nOther\r\n',
+        'Enter other sources (optional)': 'some other sources',
+      })
+    })
+
+    describe('when a single checkbox is selected', () => {
+      it('converts the string value to an array before returning the formatted data', () => {
+        const body: Partial<InformationSourcesBody> = {
+          informationSources: ['interview'],
+        }
+
+        const page = new InformationSources(body, application)
+
+        expect(page.response()).toEqual({
+          "Where did you get the information on the applicant's health needs from?":
+            'In person interview with applicant\r\n',
+          'Enter other sources (optional)': '',
+        })
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/risks-and-needs/health-needs/informationSources.ts
+++ b/server/form-pages/apply/risks-and-needs/health-needs/informationSources.ts
@@ -67,4 +67,22 @@ export default class InformationSources implements TaskListPage {
       delete this.body.otherSourcesDetail
     }
   }
+
+  response() {
+    const response: Record<string, string> = {}
+
+    const sourcesArr = Array.isArray(this.body.informationSources)
+      ? this.body.informationSources
+      : [this.body.informationSources]
+
+    let sourceList = ''
+    sourcesArr.forEach(source => {
+      sourceList += `${this.questions.informationSources.answers[source]}\r\n`
+    })
+
+    response[this.questions.informationSources.question] = sourceList
+    response[this.questions.otherSourcesDetail.question] = this.body.otherSourcesDetail ?? ''
+
+    return response
+  }
 }

--- a/server/form-pages/apply/risks-and-needs/risk-information/informationSources.test.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-information/informationSources.test.ts
@@ -45,4 +45,37 @@ describe('InformationSources', () => {
       })
     })
   })
+
+  describe('response', () => {
+    it('returns formatted data', () => {
+      const body: Partial<InformationSourcesBody> = {
+        informationSources: ['interview', 'police', 'casework', 'healthcare', 'ndelius', 'nomis', 'oasys', 'other'],
+        otherSourcesDetail: 'some other sources',
+      }
+
+      const page = new InformationSources(body, application)
+
+      expect(page.response()).toEqual({
+        'Where did you get the information on concerns about the applicant from?':
+          'In person interview with applicant\r\nPolice and Safeguarding teams\r\nCase work\r\nHealthcare teams\r\nNDelius (National probation database)\r\nNOMIS (National Offender Management Information System)\r\nPrevious or current OASys\r\nOther\r\n',
+        'Enter other sources (optional)': 'some other sources',
+      })
+    })
+
+    describe('when a single checkbox is selected', () => {
+      it('converts the string value to an array before returning the formatted data', () => {
+        const body: Partial<InformationSourcesBody> = {
+          informationSources: ['interview'],
+        }
+
+        const page = new InformationSources(body, application)
+
+        expect(page.response()).toEqual({
+          'Where did you get the information on concerns about the applicant from?':
+            'In person interview with applicant\r\n',
+          'Enter other sources (optional)': '',
+        })
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/risks-and-needs/risk-information/informationSources.ts
+++ b/server/form-pages/apply/risks-and-needs/risk-information/informationSources.ts
@@ -26,7 +26,7 @@ export default class InformationSources implements TaskListPage {
 
   title = 'Where did you get the information on concerns about the applicant from?'
 
-  questions = getQuestions(this.personName)['health-needs']['information-sources']
+  questions = getQuestions(this.personName)['risk-information']['information-sources']
 
   body: InformationSourcesBody
 
@@ -66,5 +66,23 @@ export default class InformationSources implements TaskListPage {
     if (!this.body.informationSources.includes('other')) {
       delete this.body.otherSourcesDetail
     }
+  }
+
+  response() {
+    const response: Record<string, string> = {}
+
+    const sourcesArr = Array.isArray(this.body.informationSources)
+      ? this.body.informationSources
+      : [this.body.informationSources]
+
+    let sourceList = ''
+    sourcesArr.forEach(source => {
+      sourceList += `${this.questions.informationSources.answers[source]}\r\n`
+    })
+
+    response[this.questions.informationSources.question] = sourceList
+    response[this.questions.otherSourcesDetail.question] = this.body.otherSourcesDetail ?? ''
+
+    return response
   }
 }


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-367

# Changes in this PR

- adds a response method to the information sources page to ensure user friendly rendering of data on the check your answers page

## Screenshots of UI changes

### Before

### After

![Screenshot 2025-05-09 at 10 55 53](https://github.com/user-attachments/assets/32c9173e-593b-4314-b4c3-f7aa99416e92)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
