### PR TITLE
Retain data on save for bail hearing information page

### DIFF
--- a/server/form-pages/apply/bail-information/bail-hearing-information/bailHearingInformation.test.ts
+++ b/server/form-pages/apply/bail-information/bail-hearing-information/bailHearingInformation.test.ts
@@ -126,11 +126,13 @@ describe('BailHearingInformation', () => {
         application,
       )
 
-      it('deletes all other fields', () => {
+      it('deletes the date fields', () => {
         page.onSave()
 
         expect(page.body).toEqual({
           isBailHearingDateKnown: 'no',
+          courtName: 'some court',
+          bailHearingMedium: 'judgeInChambers',
         })
       })
     })

--- a/server/form-pages/apply/bail-information/bail-hearing-information/bailHearingInformation.ts
+++ b/server/form-pages/apply/bail-information/bail-hearing-information/bailHearingInformation.ts
@@ -96,8 +96,6 @@ export default class BailHearingInformation implements TaskListPage {
       delete this.body['bailHearingDate-day']
       delete this.body['bailHearingDate-month']
       delete this.body['bailHearingDate-year']
-      delete this.body.courtName
-      delete this.body.bailHearingMedium
     }
   }
 


### PR DESCRIPTION
We have decided to retain the court name and hearing medium because we believe it may be possible that this data is known even if the date is not.

# Context

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
