### PR TITLE
Cba 505 users with cas 2 assessor role can view reports

### DIFF
--- a/integration_tests/pages/reports/managementInfoDownloadsPage.ts
+++ b/integration_tests/pages/reports/managementInfoDownloadsPage.ts
@@ -1,0 +1,43 @@
+import Page from '../page'
+import paths from '../../../server/paths/report'
+
+export default class ManagementInfoDownloadsPage extends Page {
+  constructor() {
+    super('Management information reports', undefined)
+    this.pageHasMiTitle()
+    this.pageIncludesDataLimitNotice()
+  }
+
+  static visit(): ManagementInfoDownloadsPage {
+    cy.visit(paths.report.new.pattern)
+
+    return new ManagementInfoDownloadsPage()
+  }
+
+  pageHasMiTitle(): void {
+    cy.title().should('include', 'Download reports')
+  }
+
+  pageIncludesDataLimitNotice(): void {
+    cy.contains('The data in these reports is limited to the last 12 months.')
+  }
+
+  shouldShowManagementInfoDownloads(): void {
+    cy.contains('Download management information in spreadsheet format')
+    cy.contains("Download 'Submitted applications' report").should(
+      'have.attr',
+      'href',
+      paths.report.create({ name: 'submitted-applications' }),
+    )
+    cy.contains("Download 'Application status updates' report").should(
+      'have.attr',
+      'href',
+      paths.report.create({ name: 'application-status-updates' }),
+    )
+    cy.contains("Download 'Un-submitted applications' report").should(
+      'have.attr',
+      'href',
+      paths.report.create({ name: 'unsubmitted-applications' }),
+    )
+  }
+}

--- a/integration_tests/tests/reports/download_management_info.cy.ts
+++ b/integration_tests/tests/reports/download_management_info.cy.ts
@@ -1,0 +1,52 @@
+//  Feature: Management Info user views download links
+//    So that I can analyse usage of the service
+//    As a MI User
+//    I want to download reports based on domain events
+//
+//    Scenario: download management information
+//      Given I am logged in as an Management Information user
+//      When I visit the management info reports page
+//      Then I see the download links
+//
+//    Scenario: try to access reports without the correct role
+//      Given I am logged in as a referrer
+//      When I visit the management info reports page
+//      Then I see an unauthorised screen
+
+import Page from '../../pages/page'
+import ManagementInfoDownloadsPage from '../../pages/reports/managementInfoDownloadsPage'
+
+context('Management information downloads', () => {
+  beforeEach(() => {
+    cy.task('reset')
+  })
+
+  //  Scenario: download management information
+  it('provides a list of download links', function test() {
+    // Given I am logged in as a Management Information user
+    cy.task('stubSignIn', { roles: ['CAS2_MI'] })
+    cy.task('stubAuthUser')
+    cy.signIn()
+
+    //  When I visit the management info reports page
+    ManagementInfoDownloadsPage.visit()
+    const page = Page.verifyOnPage(ManagementInfoDownloadsPage)
+
+    //  Then see the download links
+    page.shouldShowManagementInfoDownloads()
+  })
+
+  //  Scenario: try to access reports without the correct role
+  it('redirects to the not authorised page', () => {
+    //  Given I am logged in as a referrer
+    cy.task('stubSignIn', { roles: ['CAS2_PRISON_BAIL_REFERRER'] })
+    cy.task('stubAuthUser')
+    cy.signIn()
+
+    //  When I visit the management info reports page
+    cy.visit('/reports')
+
+    //  Then I see an unauthorised screen
+    cy.get('h1').contains('You are not authorised to view this page.')
+  })
+})

--- a/server/controllers/report/reportsController.test.ts
+++ b/server/controllers/report/reportsController.test.ts
@@ -27,12 +27,28 @@ describe('reportsController', () => {
   })
 
   describe('new', () => {
-    it('renders the template', async () => {
-      const requestHandler = reportsController.new()
+    describe('when user has ROLE_MI', () => {
+      it('renders the template', async () => {
+        response.locals.user.userRoles = ['CAS2_MI', 'CAS2_ASSESSOR']
 
-      await requestHandler(request, response, next)
+        const requestHandler = reportsController.new()
 
-      expect(response.render).toHaveBeenCalledWith('reports/new', {})
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('reports/new', {})
+      })
+    })
+
+    describe('when user does not have ROLE_MI', () => {
+      it('redirects to the unauthorised page', async () => {
+        response.locals.user.userRoles = ['CAS2_COURT_BAIL_REFERRER', 'CAS2_ASSESSOR']
+
+        const requestHandler = reportsController.new()
+
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(paths.report.unauthorised({}))
+      })
     })
   })
 
@@ -55,6 +71,18 @@ describe('reportsController', () => {
       await requestHandler(request, response, next)
 
       expect(response.redirect).toHaveBeenCalledWith(paths.report.new({}))
+    })
+  })
+
+  describe('unauthorised', () => {
+    it('renders the template', async () => {
+      const requestHandler = reportsController.unauthorised()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('reports/unauthorised', {
+        pageHeading: 'You are not authorised to view this page.',
+      })
     })
   })
 })

--- a/server/controllers/report/reportsController.ts
+++ b/server/controllers/report/reportsController.ts
@@ -1,12 +1,16 @@
 import { Request, RequestHandler, Response, TypedRequestHandler } from 'express'
 import paths from '../../paths/report'
 import ReportService from '../../services/reportService'
+import { hasRole } from '../../utils/userUtils'
 
 export default class ReportsController {
   constructor(private readonly reportsService: ReportService) {}
 
   new(): RequestHandler {
     return async (_req: Request, res: Response) => {
+      if (!hasRole(res.locals.user.userRoles, 'CAS2_MI')) {
+        return res.redirect(paths.report.unauthorised({}))
+      }
       return res.render('reports/new', {})
     }
   }
@@ -18,6 +22,12 @@ export default class ReportsController {
       } catch {
         return res.redirect(paths.report.new({}))
       }
+    }
+  }
+
+  unauthorised(): RequestHandler {
+    return async (_req: Request, res: Response) => {
+      return res.render('reports/unauthorised', { pageHeading: 'You are not authorised to view this page.' })
     }
   }
 }

--- a/server/paths/report.ts
+++ b/server/paths/report.ts
@@ -7,5 +7,6 @@ export default {
   report: {
     new: reportPath,
     create: singleReportPath,
+    unauthorised: reportPath.path('unauthorised'),
   },
 }

--- a/server/routes/report.ts
+++ b/server/routes/report.ts
@@ -15,6 +15,9 @@ export default function reportRoutes(controllers: Controllers, router: Router, s
   get(paths.report.new.pattern, reportController.new(), {
     auditEvent: 'LIST_REPORTS',
   })
+  get(paths.report.unauthorised.pattern, reportController.unauthorised(), {
+    auditEvent: 'LIST_REPORTS_UNAUTHORISED',
+  })
   get(paths.report.create.pattern, reportController.create(), {
     auditEvent: 'DOWNLOAD_REPORT',
   })

--- a/server/views/reports/unauthorised.njk
+++ b/server/views/reports/unauthorised.njk
@@ -1,0 +1,16 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+     <h1>{{pageHeading}}</h1>
+    </div>
+  </div>
+{% endblock %}
+


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-505

# Changes in this PR

Adds a new role check to prevent users without the role "CAS2_MI" from viewing the reports page.

## Screenshots of UI changes

![Screenshot 2025-05-13 at 11 56 45](https://github.com/user-attachments/assets/fc88dce7-c12d-499e-9fa6-9d1f59c27e12)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
