### PR TITLE
Update @pact-foundation/pact to v15.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
       "devDependencies": {
         "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
         "@ministryofjustice/eslint-config-hmpps": "^0.0.1-beta.2",
-        "@pact-foundation/pact": "^14.0.0",
+        "@pact-foundation/pact": "^15.0.1",
         "@tsconfig/node22": "^22.0.1",
         "@types/bunyan": "^1.8.11",
         "@types/bunyan-format": "^0.2.9",
@@ -3956,17 +3956,18 @@
       }
     },
     "node_modules/@pact-foundation/pact": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact/-/pact-14.0.0.tgz",
-      "integrity": "sha512-wdPGHSbj+RPKqzNN4/JB5Xua9NVTc6LNZdY91x5xN/ISQsCvzmoPny2WAvWP5dNUSvhNGvqi+rkrKxK7xXDt8w==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact/-/pact-15.0.1.tgz",
+      "integrity": "sha512-9pv9mN/grXiXCPmyzQb9YYeyT8aHYO4uRNtfuR4IGLhNSHkHIhiS97ZUsegPruVkWiTcCv9tJahG+1OhL5BrTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@pact-foundation/pact-core": "^16.0.0",
-        "axios": "^1.7.8",
+        "axios": "^1.8.4",
         "body-parser": "^1.20.3",
         "chalk": "4.1.2",
         "express": "^4.21.1",
+        "graphql": "^16.10.0",
         "graphql-tag": "^2.9.1",
         "http-proxy": "^1.18.1",
         "https-proxy-agent": "^7.0.4",
@@ -11281,7 +11282,6 @@
       "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   "devDependencies": {
     "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
     "@ministryofjustice/eslint-config-hmpps": "^0.0.1-beta.2",
-    "@pact-foundation/pact": "^14.0.0",
+    "@pact-foundation/pact": "^15.0.1",
     "@tsconfig/node22": "^22.0.1",
     "@types/bunyan": "^1.8.11",
     "@types/bunyan-format": "^0.2.9",


### PR DESCRIPTION
The latest version of Pact updates the version of Axios it depends on. Since we have had previous security alerts relating to the existing version of Axios, we should update Pact.

# Context

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
