### PR TITLE
Enable openAPI test

### DIFF
--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -176,6 +176,7 @@ describeClient('ApplicationClient', provider => {
         translatedDocument: application.document,
         applicationId: application.id,
         telephoneNumber: '123',
+        applicationOrigin: 'courtBail',
       } as SubmitCas2v2Application
 
       provider.addInteraction({

--- a/server/testutils/describeClient.ts
+++ b/server/testutils/describeClient.ts
@@ -17,8 +17,7 @@ const describeClient = (consumer: string, fn: (provider: Pact) => void) => {
       fn(pact)
     })
 
-    // Temporarily disable test due to swagger-mock-validator error
-    xit('meets the contract for the service', () => {
+    it('meets the contract for the service', () => {
       const pactPath = `${dir}/${consumer}-${provider}.json`
       expect(pactPath).toMatchOpenAPISpec()
     })

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -28,9 +28,9 @@ expect.extend({
   },
   toMatchOpenAPISpec(pactPath) {
     const openAPIUrl =
-      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/codegen/built-cas2-api-spec.yml'
+      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/codegen/built-cas2v2-api-spec.yml'
 
-    const openAPIPath = path.join(__dirname, '..', '..', 'tmp', 'cas2-api.yml')
+    const openAPIPath = path.join(__dirname, '..', '..', 'tmp', 'cas2v2-api.yml')
 
     try {
       execSync(`


### PR DESCRIPTION
# Context
This will cause open PRs to fail when an update to the API schema is detected, ensuring incompatible code isn't merged before the schema update.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
