### PR TITLE
Revert "Add context to conditional radios on the gang affiliation page"

### DIFF
--- a/e2e-tests/pages/basePage.ts
+++ b/e2e-tests/pages/basePage.ts
@@ -45,12 +45,12 @@ export default class BasePage {
     await this.page.getByTestId(testId).check()
   }
 
-  async checkRadioInGroup(group: string, label: string, exact: boolean = true) {
+  async checkRadioInGroup(group: string, label: string) {
     await this.page
       .getByRole('group', {
         name: group,
       })
-      .getByLabel(label, { exact })
+      .getByLabel(label, { exact: true })
       .check()
   }
 

--- a/e2e-tests/steps/areaAndFundingSection.ts
+++ b/e2e-tests/steps/areaAndFundingSection.ts
@@ -77,7 +77,7 @@ async function completeExclusionZonesPage(page: Page, name: string) {
 async function completeGangAffiliations(page: Page, name: string) {
   const exclusionZonesPage = await ApplyPage.initialize(page, `Gang affiliation details for ${name}`)
 
-  await exclusionZonesPage.checkRadioInGroup('any gang affiliations', 'Yes', false)
+  await exclusionZonesPage.checkRadioInGroup('any gang affiliations', 'Yes')
   await exclusionZonesPage.fillField('details of the gang', 'Gang name')
   await exclusionZonesPage.checkRadioInGroup('rival gangs', 'Yes')
 

--- a/server/views/applications/pages/area-information/gang-affiliations.njk
+++ b/server/views/applications/pages/area-information/gang-affiliations.njk
@@ -38,7 +38,7 @@
         {
           fieldName: "rivalGangsOrCountyLinesDetail",
           label: {
-            html: "<span class='govuk-visually-hidden'>You selected yes. Answer one additional question.</span>" + page.questions.rivalGangsOrCountyLinesDetail.question,
+            text: page.questions.rivalGangsOrCountyLinesDetail.question,
             classes: "govuk-label--s"
           }
         },
@@ -53,7 +53,7 @@
         {
           fieldName: "rivalGangNotKnownDetail",
           label: {
-            html: "<span class='govuk-visually-hidden'>You selected not known. Answer one additional question.</span>" + page.questions.rivalGangNotKnownDetail.question,
+            text: page.questions.rivalGangNotKnownDetail.question,
             classes: "govuk-label--s"
           }
         },
@@ -75,7 +75,7 @@
         items: [
           {
             value: "yes",
-            html: "Yes <span class='govuk-visually-hidden'>You selected yes. Answer one additional question.</span>",
+            text: "Yes",
             conditional: {
               html: gangAffiliationDetailHtml
             }
@@ -86,7 +86,7 @@
           },
           {
             value: "dontKnow",
-            html: "Not known <span class='govuk-visually-hidden'>You selected not known. Answer one additional question.</span>",
+            text: "Not known",
             conditional: {
               html: gangNotKnownDetailHtml
             }


### PR DESCRIPTION
This was merged for testing purposes and can now be rolled back.

Reverts ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui#343