### PR TITLE
Move health needs page titles to align with questions

### DIFF
--- a/e2e-tests/steps/risksAndNeedsSection.ts
+++ b/e2e-tests/steps/risksAndNeedsSection.ts
@@ -96,7 +96,10 @@ async function completeBrainInjuryPage(page: Page, name: string) {
 }
 
 async function completeLiaisonAndDiversionPage(page: Page, name: string) {
-  const liaisonAndDiversionPage = await ApplyPage.initialize(page, `Liaison and Diversion Assessment for ${name}`)
+  const liaisonAndDiversionPage = await ApplyPage.initialize(
+    page,
+    `Has a Liaison and Diversion Assessment been carried out for ${name}?`,
+  )
 
   await liaisonAndDiversionPage.checkRadioInGroup('Liaison and Diversion Assessment', 'No')
 

--- a/integration_tests/pages/apply/health_needs/health-needs/liaisonAndDiversionPage.ts
+++ b/integration_tests/pages/apply/health_needs/health-needs/liaisonAndDiversionPage.ts
@@ -7,7 +7,7 @@ import { nameOrPlaceholderCopy } from '../../../../../server/utils/utils'
 export default class LiaisonAndDiversionPage extends ApplyPage {
   constructor(private readonly application: Application) {
     super(
-      `Liaison and Diversion Assessment for ${nameOrPlaceholderCopy(application.person)}`,
+      `Has a Liaison and Diversion Assessment been carried out for ${nameOrPlaceholderCopy(application.person)}`,
       application,
       'health-needs',
       'liaison-and-diversion',

--- a/server/views/applications/pages/health-needs/_health-needs-screen.njk
+++ b/server/views/applications/pages/health-needs/_health-needs-screen.njk
@@ -6,12 +6,6 @@
 
 {% block content %}
   <div class="govuk-grid-row" id="{{ pageName }}">
-    <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ page.title }}</h1>
-    </div>
-  </div>
-
-  <div class="govuk-grid-row govuk-!-margin-top-4">
     <div class="govuk-grid-column-one-third">
       {{ mojSideNavigation({
           label: 'Health needs navigation',

--- a/server/views/applications/pages/health-needs/brain-injury.njk
+++ b/server/views/applications/pages/health-needs/brain-injury.njk
@@ -79,6 +79,8 @@
     }}
   {% endset %}
 
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
   <p class="govuk-hint">
     This could be as a result of accident, drug and alcohol use or an inherited or pre-existing condition.
   </p>

--- a/server/views/applications/pages/health-needs/communication-and-language.njk
+++ b/server/views/applications/pages/health-needs/communication-and-language.njk
@@ -33,6 +33,8 @@
     }}
   {% endset %}
 
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
    {{
     formPageRadios(
       {

--- a/server/views/applications/pages/health-needs/health-needs-information.njk
+++ b/server/views/applications/pages/health-needs/health-needs-information.njk
@@ -4,6 +4,9 @@
 {% set pageName = "health-needs-information" %}
 
 {% block questions %}
+
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
   <div data-testid="health-needs-guidance">
     <p>We will now ask you to provide information about any health needs that affect the applicant. For example, details of:</p>
 

--- a/server/views/applications/pages/health-needs/information-sources.njk
+++ b/server/views/applications/pages/health-needs/information-sources.njk
@@ -18,6 +18,8 @@
     }}
   {% endset %}
 
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
   {{ 
     formPageCheckboxes(
         {

--- a/server/views/applications/pages/health-needs/learning-difficulties.njk
+++ b/server/views/applications/pages/health-needs/learning-difficulties.njk
@@ -64,6 +64,8 @@
     }}
   {% endset %}
 
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
   <p class="govuk-body guidance">
     Neurodiversity covers Autism, ADHD, ADD, Dyslexia, Dyscalculia and Dyspraxia.
   </p>

--- a/server/views/applications/pages/health-needs/liaison-and-diversion.njk
+++ b/server/views/applications/pages/health-needs/liaison-and-diversion.njk
@@ -10,7 +10,8 @@
         fieldset: {
           legend: {
             text: page.questions.liaisonAndDiversionAssessment.question,
-            classes: "govuk-fieldset__legend--m"
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
           }
         },
         hint: { text: page.questions.liaisonAndDiversionAssessment.hint },

--- a/server/views/applications/pages/health-needs/mental-health.njk
+++ b/server/views/applications/pages/health-needs/mental-health.njk
@@ -66,6 +66,8 @@
     }}
   {% endset %}
 
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
   {{
     formPageRadios(
       {

--- a/server/views/applications/pages/health-needs/other-health.njk
+++ b/server/views/applications/pages/health-needs/other-health.njk
@@ -48,6 +48,8 @@
     }}
   {% endset %}
 
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
   <p class="govuk-hint govuk-!-margin-bottom-6">These could be any other health needs that are relevant to the support the applicant might need when living in shared accommodation.</p>
 
   {{

--- a/server/views/applications/pages/health-needs/physical-health.njk
+++ b/server/views/applications/pages/health-needs/physical-health.njk
@@ -48,6 +48,8 @@
     }}
   {% endset %}
 
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
   {{
     formPageRadios(
       {

--- a/server/views/applications/pages/health-needs/substance-misuse.njk
+++ b/server/views/applications/pages/health-needs/substance-misuse.njk
@@ -54,6 +54,7 @@
     }}
   {% endset %}
 
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
   {{
     formPageRadios(


### PR DESCRIPTION
# Context
Our research showed that some users were confused by the page title placement and thought the title was for the whole health needs section.

This change aligns the page title with the questions so it's more obvious.

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Screenshots of UI changes

### Before
![Screenshot 2025-06-03 at 10 46 23](https://github.com/user-attachments/assets/ea870fd6-558c-4d2c-a0b0-79526fa6b387)
![Screenshot 2025-06-03 at 10 46 29](https://github.com/user-attachments/assets/de43d2a2-74eb-4d07-9dc3-0d07789b6900)

### After
![Screenshot 2025-06-03 at 10 27 43](https://github.com/user-attachments/assets/0c5078c1-8fbf-4cfa-b4ae-4554cc3c38d7)
![Screenshot 2025-06-03 at 10 39 01](https://github.com/user-attachments/assets/a5079e6b-d313-444f-bcd1-db51050c1e5a)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
