### PR TITLE
CBA-686 decide approach to relevance checks that links first and secondary pages

### DIFF
--- a/integration_tests/pages/apply/check_your_answers/check-your-answers/checkYourAnswersPage.ts
+++ b/integration_tests/pages/apply/check_your_answers/check-your-answers/checkYourAnswersPage.ts
@@ -35,9 +35,8 @@ export default class CheckYourAnswersPage extends ApplyPage {
     })
   }
 
-  shouldShowQuestionsAndAnswers(task: string, pagesWithQuestionsToExclude: Array<string> = []) {
-    const pagesWithoutQuestions = ['add-acct-note']
-    const pagesToExclude = pagesWithoutQuestions.concat(pagesWithQuestionsToExclude)
+  shouldShowQuestionsAndAnswers(task: string) {
+    const pagesToExclude = ['add-acct-note', 'brain-injury-details', 'communication-and-language']
     const pageKeys = Object.keys(this.application.data[task])
     pageKeys.forEach(pageKey => {
       if (pagesToExclude.includes(pageKey)) {

--- a/server/form-pages/apply/health-needs/health-needs/brainInjury.test.ts
+++ b/server/form-pages/apply/health-needs/health-needs/brainInjury.test.ts
@@ -28,4 +28,55 @@ describe('BrainInjury', () => {
       expect(page.errors()).toHaveProperty('hasBrainInjury', 'Select yes if they have any brain injury')
     })
   })
+
+  describe('response', () => {
+    describe('when _hasBrainInjury_ is set to NO', () => {
+      it('returns only that question', () => {
+        const page = new BrainInjury({ hasBrainInjury: 'no' }, application)
+
+        expect(page.response()).toEqual({
+          'Does Roger Smith have a brain injury?': 'No',
+        })
+      })
+    })
+
+    describe('when _hasBrainInjury_ is set to YES', () => {
+      application.data = {
+        'health-needs': {
+          'brain-injury': {
+            hasBrainInjury: 'yes',
+          },
+          'brain-injury-details': {
+            injuryDetail: 'some injury details',
+            supportNeeded: 'yes',
+            supportDetail: 'some support details',
+            receivingTreatment: 'yes',
+            treatmentDetail: 'some treatment details',
+            isVulnerable: 'yes',
+            vulnerabilityDetail: 'some vulnerability details',
+            hasDifficultyInteracting: 'yes',
+            interactionDetail: 'some interaction details',
+          },
+        },
+      }
+
+      it('returns questions and answers for both brain injury pages', () => {
+        const page = new BrainInjury({ hasBrainInjury: 'yes' }, application)
+
+        expect(page.response()).toEqual({
+          'Does Roger Smith have a brain injury?': 'Yes',
+          'Enter details of their brain injury': 'some injury details',
+          'Do they need any support as a result of this?': 'Yes',
+          'Enter details of the type of support needed, including any support they have already or will need':
+            'some support details',
+          'Do they receive any treatment for this?': 'Yes',
+          'Enter details about their treatment': 'some treatment details',
+          'Are they vulnerable as a result of this?': 'Yes',
+          'Enter details of how they might be vulnerable': 'some vulnerability details',
+          'Do they have difficulties interacting with other people as a result of their injury?': 'Yes',
+          'Enter details of the type of difficulties they have': 'some interaction details',
+        })
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/health-needs/health-needs/brainInjury.ts
+++ b/server/form-pages/apply/health-needs/health-needs/brainInjury.ts
@@ -51,4 +51,43 @@ export default class BrainInjury implements TaskListPage {
 
     return errors
   }
+
+  response() {
+    const response: Record<string, string> = {}
+
+    response[this.questions.hasBrainInjury.question] = this.questions.hasBrainInjury.answers[this.body.hasBrainInjury]
+
+    if (this.body.hasBrainInjury === 'yes') {
+      const detailsPageQuestions = getQuestions(this.personName)['health-needs']['brain-injury-details']
+      const detailsPageData = this.application.data['health-needs']['brain-injury-details']
+
+      response[detailsPageQuestions.injuryDetail.question] = detailsPageData.injuryDetail
+
+      response[detailsPageQuestions.supportNeeded.question] =
+        detailsPageQuestions.supportNeeded.answers[detailsPageData.supportNeeded as YesOrNo]
+      if (detailsPageData.supportNeeded === 'yes') {
+        response[detailsPageQuestions.supportDetail.question] = detailsPageData.supportDetail
+      }
+
+      response[detailsPageQuestions.receivingTreatment.question] =
+        detailsPageQuestions.receivingTreatment.answers[detailsPageData.receivingTreatment as YesOrNo]
+      if (detailsPageData.receivingTreatment === 'yes') {
+        response[detailsPageQuestions.treatmentDetail.question] = detailsPageData.treatmentDetail
+      }
+
+      response[detailsPageQuestions.isVulnerable.question] =
+        detailsPageQuestions.isVulnerable.answers[detailsPageData.isVulnerable as YesOrNo]
+      if (detailsPageData.isVulnerable === 'yes') {
+        response[detailsPageQuestions.vulnerabilityDetail.question] = detailsPageData.vulnerabilityDetail
+      }
+
+      response[detailsPageQuestions.hasDifficultyInteracting.question] =
+        detailsPageQuestions.hasDifficultyInteracting.answers[detailsPageData.hasDifficultyInteracting as YesOrNo]
+      if (detailsPageData.hasDifficultyInteracting === 'yes') {
+        response[detailsPageQuestions.interactionDetail.question] = detailsPageData.interactionDetail
+      }
+    }
+
+    return response
+  }
 }

--- a/server/form-pages/apply/health-needs/health-needs/communicationAndLanguageRelevanceCheck.test.ts
+++ b/server/form-pages/apply/health-needs/health-needs/communicationAndLanguageRelevanceCheck.test.ts
@@ -22,4 +22,48 @@ describe('CommunicationAndLanguageRelevanceCheck', () => {
       )
     })
   })
+
+  describe('response', () => {
+    describe('when _hasCommunicationAndLanguageNeeds_ is set to NO', () => {
+      it('returns only that question', () => {
+        const page = new CommunicationAndLanguageRelevanceCheck({ hasCommunicationAndLanguageNeeds: 'no' }, application)
+
+        expect(page.response()).toEqual({
+          'Does Roger Smith have any communication and language needs?': 'No',
+        })
+      })
+    })
+
+    describe('when _hasCommunicationAndLanguageNeeds_ is set to YES', () => {
+      application.data = {
+        'health-needs': {
+          'communication-and-language-relevance-check': {
+            hasCommunicationAndLanguageNeeds: 'yes',
+          },
+          'communication-and-language': {
+            hasImpairments: 'yes',
+            impairmentsDetail: 'some impairment details',
+            requiresInterpreter: 'yes',
+            interpretationDetail: 'some interpretation details',
+          },
+        },
+      }
+
+      it('returns questions and answers for both communication and language needs pages', () => {
+        const page = new CommunicationAndLanguageRelevanceCheck(
+          { hasCommunicationAndLanguageNeeds: 'yes' },
+          application,
+        )
+
+        expect(page.response()).toEqual({
+          'Does Roger Smith have any communication and language needs?': 'Yes',
+          'Do they have any literacy, visual or hearing impairments?': 'Yes',
+          'Enter details of their needs, including any support they have already or will need':
+            'some impairment details',
+          'Do they need an interpreter?': 'Yes',
+          'What language do they need an interpreter for?': 'some interpretation details',
+        })
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/health-needs/health-needs/communicationAndLanguageRelevanceCheck.ts
+++ b/server/form-pages/apply/health-needs/health-needs/communicationAndLanguageRelevanceCheck.ts
@@ -52,4 +52,30 @@ export default class CommunicationAndLanguageRelevanceCheck implements TaskListP
 
     return errors
   }
+
+  response() {
+    const response: Record<string, string> = {}
+
+    response[this.questions.hasCommunicationAndLanguageNeeds.question] =
+      this.questions.hasCommunicationAndLanguageNeeds.answers[this.body.hasCommunicationAndLanguageNeeds]
+
+    if (this.body.hasCommunicationAndLanguageNeeds === 'yes') {
+      const detailsPageQuestions = getQuestions(this.personName)['health-needs']['communication-and-language']
+      const detailsPageData = this.application.data['health-needs']['communication-and-language']
+
+      response[detailsPageQuestions.hasImpairments.question] =
+        detailsPageQuestions.hasImpairments.answers[detailsPageData.hasImpairments as YesOrNo]
+      if (detailsPageData.hasImpairments === 'yes') {
+        response[detailsPageQuestions.impairmentsDetail.question] = detailsPageData.impairmentsDetail
+      }
+
+      response[detailsPageQuestions.requiresInterpreter.question] =
+        detailsPageQuestions.requiresInterpreter.answers[detailsPageData.requiresInterpreter as YesOrNo]
+      if (detailsPageData.requiresInterpreter === 'yes') {
+        response[detailsPageQuestions.interpretationDetail.question] = detailsPageData.interpretationDetail
+      }
+    }
+
+    return response
+  }
 }

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -40,7 +40,7 @@ export const getTaskAnswersAsSummaryListItems = (
   const questions = getQuestions(nameOrPlaceholderCopy(application.person))
 
   // Get the page keys stored on the application at creation
-  const applicationPageKeys = getKeysForPages(application, task)
+  const applicationPageKeys = getKeysForPages(application, task).filter(key => pagesWeNeverWantToPresent(key) === false)
 
   // Filter out any keys that are no longer in the latest question schema
   const relevantPagesKeys = removeAnyOldPageKeys(questions, task, applicationPageKeys)
@@ -316,4 +316,8 @@ export const removeAnyOldPageKeys = (questions: any, task: string, applicationPa
     key => latestPageKeys.includes(key) || ['acct', 'alleged-offences', 'unspent-convictions'].includes(key),
   )
   return matchedKeys
+}
+
+const pagesWeNeverWantToPresent = (key: string): boolean => {
+  return ['brain-injury-details'].includes(key)
 }

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -319,5 +319,5 @@ export const removeAnyOldPageKeys = (questions: any, task: string, applicationPa
 }
 
 const pagesWeNeverWantToPresent = (key: string): boolean => {
-  return ['brain-injury-details'].includes(key)
+  return ['brain-injury-details', 'communication-and-language'].includes(key)
 }


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-686

During manual testing we noticed that for the relevance check pages, there is a possibility that the cover page and the details page will be presented separately on the check your answers page, which may confuse referrers and assessors. 

# Changes in this PR

To ensure that they will be presented together, we return answers for both pages (if applicable) from the cover page via a response method, and explicitly 'ignore' the details page when generating the check your answers page.

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
