### PR TITLE
Check if ID documents field is defined before chaining includes method

### DIFF
--- a/server/form-pages/apply/area-and-funding/funding-information/applicantID.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/applicantID.ts
@@ -46,7 +46,7 @@ export default class ApplicantID implements TaskListPage {
   }
 
   next() {
-    if (this.body.idDocuments.includes('none')) {
+    if (this.body.idDocuments?.includes('none')) {
       return 'alternative-applicant-id'
     }
     return ''


### PR DESCRIPTION
When we made the changes to the confirm consent page, we moved the page.next() call in the pagesController update method above the applicationService.save() method: https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui/blob/bf8a917c9f2ffe61cac1d528b08b692f42ecc24c/server/controllers/apply/applications/pagesController.ts#L55.

We did this so that on the consent page we could work out the next page before removing the page data if the referrer answers no. However, in the case of the applicant ID page, page.next() relies on page.body.idDocuments being defined, which it will not be if no answer has been selected. And yet page.next() will be called before page.errors(), which is called inside applicationService.save().

This check will solve that problem, and is the only place I can see the issue in the codebase. However, it’s a fix that may need to be repeated in future cases. Therefore we may well revisit this shortly with a different solution.

# Context

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
