### PR TITLE
CBA-667: add fields to concerns information sources page

### DIFF
--- a/integration_tests/pages/apply/health_needs/health-needs/informationSourcesPage.ts
+++ b/integration_tests/pages/apply/health_needs/health-needs/informationSourcesPage.ts
@@ -29,7 +29,9 @@ export default class InformationSourcesPage extends ApplyPage {
 
   completeForm(): void {
     this.checkCheckboxByValue('healthcare')
+    this.checkCheckboxByValue('previousOasys')
     this.checkCheckboxByValue('other')
+    this.completeDateInputs('previousOasysDate', '2022-10-04')
     this.getTextInputByIdAndEnterDetails('otherSourcesDetail', 'some other sources')
   }
 }

--- a/integration_tests/pages/apply/offences-and-concerns/risk-information/informationSourcesPage.ts
+++ b/integration_tests/pages/apply/offences-and-concerns/risk-information/informationSourcesPage.ts
@@ -29,7 +29,9 @@ export default class InformationSourcesPage extends ApplyPage {
 
   completeForm(): void {
     this.checkCheckboxByValue('healthcare')
+    this.checkCheckboxByValue('previousOasys')
     this.checkCheckboxByValue('other')
+    this.completeDateInputs('previousOasysDate', '2022-10-04')
     this.getTextInputByIdAndEnterDetails('otherSourcesDetail', 'some other sources')
   }
 }

--- a/server/form-pages/apply/health-needs/health-needs/informationSources.test.ts
+++ b/server/form-pages/apply/health-needs/health-needs/informationSources.test.ts
@@ -27,6 +27,57 @@ describe('InformationSources', () => {
         )
       })
     })
+
+    describe('when previous OASys is selected', () => {
+      describe('and no previous OASys date is entered', () => {
+        const body: Partial<InformationSourcesBody> = {
+          informationSources: ['previousOasys'],
+        }
+
+        it('includes a validation error for _previousOasysDate_', () => {
+          const page = new InformationSources(body, application)
+
+          expect(page.errors()).toHaveProperty(
+            'previousOasysDate',
+            'Previous OASys date must include a day, month and year',
+          )
+        })
+      })
+    })
+
+    describe('when previous OASys is selected', () => {
+      describe('and the previous OASys date is not a valid date', () => {
+        const body: Partial<InformationSourcesBody> = {
+          informationSources: ['previousOasys'],
+          'previousOasysDate-year': '1122',
+          'previousOasysDate-month': '13',
+          'previousOasysDate-day': '32',
+        }
+
+        it('includes a validation error for _previousOasysDate_', () => {
+          const page = new InformationSources(body, application)
+
+          expect(page.errors()).toHaveProperty('previousOasysDate', 'Previous OASys date must be a real date')
+        })
+      })
+    })
+
+    describe('when previous OASys is selected', () => {
+      describe('and the previous OASys date is in the future', () => {
+        const body: Partial<InformationSourcesBody> = {
+          informationSources: ['previousOasys'],
+          'previousOasysDate-year': '3000',
+          'previousOasysDate-month': '11',
+          'previousOasysDate-day': '03',
+        }
+
+        it('includes a validation error for _previousOasysDate_', () => {
+          const page = new InformationSources(body, application)
+
+          expect(page.errors()).toHaveProperty('previousOasysDate', 'Previous OASys date must be in the past')
+        })
+      })
+    })
   })
 
   describe('onSave', () => {
@@ -49,7 +100,20 @@ describe('InformationSources', () => {
   describe('response', () => {
     it('returns formatted data', () => {
       const body: Partial<InformationSourcesBody> = {
-        informationSources: ['interview', 'police', 'casework', 'healthcare', 'ndelius', 'nomis', 'oasys', 'other'],
+        informationSources: [
+          'interview',
+          'police',
+          'casework',
+          'healthcare',
+          'ndelius',
+          'nomis',
+          'previousOasys',
+          'currentOasys',
+          'other',
+        ],
+        'previousOasysDate-month': '10',
+        'previousOasysDate-year': '2023',
+        'previousOasysDate-day': '01',
         otherSourcesDetail: 'some other sources',
       }
 
@@ -57,7 +121,8 @@ describe('InformationSources', () => {
 
       expect(page.response()).toEqual({
         "Where did you get the information on the applicant's health needs from?":
-          'In person interview with applicant\r\nPolice and Safeguarding teams\r\nCase work\r\nHealthcare teams\r\nNDelius (National probation database)\r\nNOMIS (National Offender Management Information System)\r\nPrevious or current OASys\r\nOther\r\n',
+          'In person interview with applicant\r\nPolice and Safeguarding teams\r\nCase work\r\nHealthcare teams\r\nNDelius (National probation database)\r\nNOMIS (National Offender Management Information System)\r\nPrevious OASys\r\nCurrent OASys\r\nOther\r\n',
+        'Enter date of previous OASys': '1 October 2023',
         'Enter other sources (optional)': 'some other sources',
       })
     })

--- a/server/form-pages/apply/offences-and-concerns/risk-information/informationSources.test.ts
+++ b/server/form-pages/apply/offences-and-concerns/risk-information/informationSources.test.ts
@@ -27,6 +27,57 @@ describe('InformationSources', () => {
         )
       })
     })
+
+    describe('when previous OASys is selected', () => {
+      describe('and no previous OASys date is entered', () => {
+        const body: Partial<InformationSourcesBody> = {
+          informationSources: ['previousOasys'],
+        }
+
+        it('includes a validation error for _previousOasysDate_', () => {
+          const page = new InformationSources(body, application)
+
+          expect(page.errors()).toHaveProperty(
+            'previousOasysDate',
+            'Previous OASys date must include a day, month and year',
+          )
+        })
+      })
+    })
+
+    describe('when previous OASys is selected', () => {
+      describe('and the previous OASys date is not a valid date', () => {
+        const body: Partial<InformationSourcesBody> = {
+          informationSources: ['previousOasys'],
+          'previousOasysDate-year': '1122',
+          'previousOasysDate-month': '13',
+          'previousOasysDate-day': '32',
+        }
+
+        it('includes a validation error for _previousOasysDate_', () => {
+          const page = new InformationSources(body, application)
+
+          expect(page.errors()).toHaveProperty('previousOasysDate', 'Previous OASys date must be a real date')
+        })
+      })
+    })
+
+    describe('when previous OASys is selected', () => {
+      describe('and the previous OASys date is in the future', () => {
+        const body: Partial<InformationSourcesBody> = {
+          informationSources: ['previousOasys'],
+          'previousOasysDate-year': '3000',
+          'previousOasysDate-month': '11',
+          'previousOasysDate-day': '03',
+        }
+
+        it('includes a validation error for _previousOasysDate_', () => {
+          const page = new InformationSources(body, application)
+
+          expect(page.errors()).toHaveProperty('previousOasysDate', 'Previous OASys date must be in the past')
+        })
+      })
+    })
   })
 
   describe('onSave', () => {
@@ -49,7 +100,20 @@ describe('InformationSources', () => {
   describe('response', () => {
     it('returns formatted data', () => {
       const body: Partial<InformationSourcesBody> = {
-        informationSources: ['interview', 'police', 'casework', 'healthcare', 'ndelius', 'nomis', 'oasys', 'other'],
+        informationSources: [
+          'interview',
+          'police',
+          'casework',
+          'healthcare',
+          'ndelius',
+          'nomis',
+          'previousOasys',
+          'currentOasys',
+          'other',
+        ],
+        'previousOasysDate-month': '10',
+        'previousOasysDate-year': '2023',
+        'previousOasysDate-day': '01',
         otherSourcesDetail: 'some other sources',
       }
 
@@ -57,7 +121,8 @@ describe('InformationSources', () => {
 
       expect(page.response()).toEqual({
         'Where did you get the information on concerns about the applicant from?':
-          'In person interview with applicant\r\nPolice and Safeguarding teams\r\nCase work\r\nHealthcare teams\r\nNDelius (National probation database)\r\nNOMIS (National Offender Management Information System)\r\nPrevious or current OASys\r\nOther\r\n',
+          'In person interview with applicant\r\nPolice and Safeguarding teams\r\nCase work\r\nHealthcare teams\r\nNDelius (National probation database)\r\nNOMIS (National Offender Management Information System)\r\nPrevious OASys\r\nCurrent OASys\r\nOther\r\n',
+        'Enter date of previous OASys': '1 October 2023',
         'Enter other sources (optional)': 'some other sources',
       })
     })

--- a/server/form-pages/apply/offences-and-concerns/risk-information/informationSources.ts
+++ b/server/form-pages/apply/offences-and-concerns/risk-information/informationSources.ts
@@ -1,10 +1,18 @@
-import type { TaskListErrors } from '@approved-premises/ui'
+/* eslint-disable no-param-reassign */
+import type { ObjectWithDateParts, Radio, TaskListErrors } from '@approved-premises/ui'
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
 import { getQuestions } from '../../../utils/questions'
 import { convertKeyValuePairToCheckboxItems } from '../../../../utils/formUtils'
+import { dateBodyProperties } from '../../../utils'
+import {
+  dateAndTimeInputsAreValidDates,
+  DateFormats,
+  dateIsComplete,
+  dateIsTodayOrInTheFuture,
+} from '../../../../utils/dateUtils'
 
 const applicationQuestions = getQuestions('')
 
@@ -13,11 +21,11 @@ export const options = applicationQuestions['risk-information']['information-sou
 export type InformationSourcesBody = {
   informationSources: Array<keyof typeof options>
   otherSourcesDetail: string
-}
+} & ObjectWithDateParts<'previousOasysDate'>
 
 @Page({
   name: 'information-sources',
-  bodyProperties: ['informationSources', 'otherSourcesDetail'],
+  bodyProperties: ['informationSources', ...dateBodyProperties('previousOasysDate'), 'otherSourcesDetail'],
 })
 export default class InformationSources implements TaskListPage {
   documentTitle = 'Where did you get the information on concerns about the applicant from?'
@@ -45,10 +53,16 @@ export default class InformationSources implements TaskListPage {
     return ''
   }
 
-  items(otherSourcesDetail: string) {
-    const items = convertKeyValuePairToCheckboxItems(options, this.body.informationSources)
-    const other = items.pop()
+  items(otherSourcesDetail: string, previousOasysDate: string) {
+    const items = convertKeyValuePairToCheckboxItems(options, this.body.informationSources) as [Radio]
 
+    items.forEach(item => {
+      if (item.value === 'previousOasys') {
+        item.conditional = { html: previousOasysDate }
+      }
+    })
+
+    const other = items.pop()
     return [...items, { ...other, conditional: { html: otherSourcesDetail } }]
   }
 
@@ -57,6 +71,14 @@ export default class InformationSources implements TaskListPage {
 
     if (!this.body.informationSources) {
       errors.informationSources = 'Select where you got the information on concerns from'
+    } else if (this.body.informationSources.includes('previousOasys')) {
+      if (!dateIsComplete(this.body, 'previousOasysDate')) {
+        errors.previousOasysDate = 'Previous OASys date must include a day, month and year'
+      } else if (!dateAndTimeInputsAreValidDates(this.body, 'previousOasysDate')) {
+        errors.previousOasysDate = 'Previous OASys date must be a real date'
+      } else if (dateIsTodayOrInTheFuture(this.body, 'previousOasysDate')) {
+        errors.previousOasysDate = 'Previous OASys date must be in the past'
+      }
     }
 
     return errors
@@ -81,6 +103,14 @@ export default class InformationSources implements TaskListPage {
     })
 
     response[this.questions.informationSources.question] = sourceList
+
+    if (sourcesArr.includes('previousOasys')) {
+      response[this.questions.previousOasysDate.question] = DateFormats.dateAndTimeInputsToUiDate(
+        { ...this.body, informationSources: null },
+        'previousOasysDate',
+      )
+    }
+
     response[this.questions.otherSourcesDetail.question] = this.body.otherSourcesDetail ?? ''
 
     return response

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -744,9 +744,13 @@ export const getQuestions = (name: string) => {
             casework: 'Case work',
             ndelius: 'NDelius (National probation database)',
             police: 'Police and Safeguarding teams',
-            oasys: 'Previous or current OASys',
+            previousOasys: 'Previous OASys',
+            currentOasys: 'Current OASys',
             other: 'Other',
           },
+        },
+        previousOasysDate: {
+          question: 'Enter date of previous OASys',
         },
         otherSourcesDetail: {
           question: 'Enter other sources (optional)',
@@ -932,9 +936,13 @@ export const getQuestions = (name: string) => {
             casework: 'Case work',
             ndelius: 'NDelius (National probation database)',
             police: 'Police and Safeguarding teams',
-            oasys: 'Previous or current OASys',
+            previousOasys: 'Previous OASys',
+            currentOasys: 'Current OASys',
             other: 'Other',
           },
+        },
+        previousOasysDate: {
+          question: 'Enter date of previous OASys',
         },
         otherSourcesDetail: {
           question: 'Enter other sources (optional)',

--- a/server/views/applications/pages/health-needs/information-sources.njk
+++ b/server/views/applications/pages/health-needs/information-sources.njk
@@ -3,6 +3,22 @@
 
 {% block questions %}
 
+{% set previousOasysFollowUp %}
+    {{ 
+        formPageDateInput( {
+        fieldName: "previousOasysDate",
+        fieldset: {
+            legend: {
+                text: page.questions.previousOasysDate.question,
+                classes: "govuk-fieldset__legend--s"
+            }
+        },
+        items: dateFieldValues('previousOasysDate', errors)
+        }, 
+        fetchContext()) 
+    }}
+{% endset -%}
+
   {% set otherSourcesFollowUp %}
     {{
       formPageTextArea(
@@ -31,7 +47,7 @@
               classes: "govuk-fieldset__legend--l"
             }
           },
-          items: page.items(otherSourcesFollowUp)
+          items: page.items(otherSourcesFollowUp, previousOasysFollowUp)
         }, 
         fetchContext()
     ) 

--- a/server/views/applications/pages/risk-information/information-sources.njk
+++ b/server/views/applications/pages/risk-information/information-sources.njk
@@ -3,6 +3,22 @@
 
 {% block questions %}
 
+  {% set previousOasysFollowUp %}
+      {{ 
+          formPageDateInput( {
+          fieldName: "previousOasysDate",
+          fieldset: {
+              legend: {
+                  text: page.questions.previousOasysDate.question,
+                  classes: "govuk-fieldset__legend--s"
+              }
+          },
+          items: dateFieldValues('previousOasysDate', errors)
+          }, 
+          fetchContext()) 
+      }}
+  {% endset -%}
+
   {% set otherSourcesFollowUp %}
     {{
       formPageTextArea(
@@ -29,7 +45,7 @@
               classes: "govuk-fieldset__legend--l"
             }
           },
-          items: page.items(otherSourcesFollowUp)
+          items: page.items(otherSourcesFollowUp, previousOasysFollowUp)
         }, 
         fetchContext()
     ) 


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-667

# Changes in this PR

- separates out previous and current OASys on information sources page
- adds a previous OASys date field where previous OASys is selected

## Screenshots of UI changes

### Before

![Screenshot 2025-06-17 at 09 18 03](https://github.com/user-attachments/assets/a0ba7a6a-7cf3-4631-afe2-d5bcb825522a)

![Screenshot 2025-06-17 at 09 17 43](https://github.com/user-attachments/assets/07e41968-a971-4e9a-80fb-8f5dde5547dd)

### After

![Screenshot 2025-06-17 at 09 14 22](https://github.com/user-attachments/assets/6085153d-c604-4da5-92a7-77a31d4253e2)

![Screenshot 2025-06-17 at 09 14 40](https://github.com/user-attachments/assets/28aab1cb-6a43-4208-9685-589fde9ba8b5)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
