### PR TITLE
CBA-688: make changes to second previous convictions page

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -337,8 +337,9 @@
         "convictionType": "arson",
         "numberOfConvictions": "3",
         "currentlyServing": "no",
-        "safeguarding": "yes",
-        "safeguardingDetail": "safeguarding detail"
+        "convictionDetails": "some conviction details",
+        "areOtherDetails": "yes",
+        "otherDetails": "other details"
       }
     ],
     "unspent-convictions": {}

--- a/integration_tests/pages/apply/offences-and-concerns/previous-unspent-convictions/unspentConvictionsDataPage.ts
+++ b/integration_tests/pages/apply/offences-and-concerns/previous-unspent-convictions/unspentConvictionsDataPage.ts
@@ -27,7 +27,8 @@ export default class UnspentConvictionsDataPage extends ApplyPage {
     this.getSelectInputByIdAndSelectAnEntry('convictionType', 'Arson')
     this.getTextInputByIdAndEnterDetails('numberOfConvictions', '4')
     this.checkRadioByNameAndValue('currentlyServing', 'yes')
-    this.checkRadioByNameAndValue('safeguarding', 'yes')
-    this.getTextInputByIdAndEnterDetails('safeguardingDetail', 'detail')
+    this.getTextInputByIdAndEnterDetails('convictionDetails', 'details about convictions')
+    this.checkRadioByNameAndValue('areOtherDetails', 'yes')
+    this.getTextInputByIdAndEnterDetails('otherDetails', 'other details')
   }
 }

--- a/integration_tests/pages/apply/offences-and-concerns/previous-unspent-convictions/unspentConvictionsPage.ts
+++ b/integration_tests/pages/apply/offences-and-concerns/previous-unspent-convictions/unspentConvictionsPage.ts
@@ -27,7 +27,8 @@ export default class UnspentConvictionsPage extends ApplyPage {
     cy.get('.govuk-summary-card__title').contains('Arson')
     cy.get('.govuk-summary-list__value').contains('3')
     cy.get('.govuk-summary-list__value').contains('No')
-    cy.get('.govuk-summary-list__value').contains('safeguarding detail')
+    cy.get('.govuk-summary-list__value').contains('some conviction details')
+    cy.get('.govuk-summary-list__value').contains('other details')
   }
 
   clickAddAnotherUnspentConviction(): void {

--- a/server/form-pages/apply/offences-and-concerns/previous-unspent-convictions/custom-forms/unspentConvictionsData.test.ts
+++ b/server/form-pages/apply/offences-and-concerns/previous-unspent-convictions/custom-forms/unspentConvictionsData.test.ts
@@ -10,8 +10,9 @@ describe('UnspentConvictionsData', () => {
       convictionType: 'Arson',
       numberOfConvictions: '3',
       currentlyServing: 'yes',
-      safeguarding: 'yes',
-      safeguardingDetail: 'safeguarding detail',
+      convictionDetails: 'some details',
+      areOtherDetails: 'yes',
+      otherDetails: 'other detail',
     },
   ]
 
@@ -37,8 +38,9 @@ describe('UnspentConvictionsData', () => {
     const requiredFields = [
       ['convictionType', 'Select the type of conviction'],
       ['numberOfConvictions', 'Enter the number of convictions of this type'],
-      ['currentlyServing', 'Select if they are serving a sentence for any of these convictions'],
-      ['safeguarding', 'Select if there are any safeguarding details to add, or if it is not known'],
+      ['currentlyServing', 'Select yes if they are serving a sentence'],
+      ['convictionDetails', 'Enter what the convictions were and when they happened'],
+      ['areOtherDetails', 'Select yes if there are other details to add'],
     ]
 
     it.each(requiredFields)('it includes a validation error for %s', (field, message) => {
@@ -48,11 +50,11 @@ describe('UnspentConvictionsData', () => {
       expect(errors[field as keyof typeof errors]).toEqual(message)
     })
 
-    it('includes validation error for safeguardingDetail when not supplied and safeguarding is "yes"', () => {
-      const page = new UnspentConvictionsData({ safeguarding: 'yes' }, application)
+    it('includes validation error for otherDetails when not supplied and areOtherDetails is "yes"', () => {
+      const page = new UnspentConvictionsData({ areOtherDetails: 'yes' }, application)
       const errors = page.errors()
 
-      expect(errors.safeguardingDetail).toEqual('Enter details of the safeguarding measures')
+      expect(errors.otherDetails).toEqual('Enter more details')
     })
   })
 

--- a/server/form-pages/apply/offences-and-concerns/previous-unspent-convictions/custom-forms/unspentConvictionsData.ts
+++ b/server/form-pages/apply/offences-and-concerns/previous-unspent-convictions/custom-forms/unspentConvictionsData.ts
@@ -1,4 +1,4 @@
-import type { SelectItem, TaskListErrors, YesNoOrDontKnow, YesOrNo } from '@approved-premises/ui'
+import type { SelectItem, TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import { Cas2v2Application } from '@approved-premises/api'
 import { Page } from '../../../../utils/decorators'
 import TaskListPage from '../../../../taskListPage'
@@ -9,13 +9,21 @@ export type UnspentConvictionsDataBody = {
   convictionType: string
   numberOfConvictions: string
   currentlyServing: YesOrNo
-  safeguarding: YesNoOrDontKnow
-  safeguardingDetail: string
+  convictionDetails: string
+  areOtherDetails: YesOrNo
+  otherDetails: string
 }
 
 @Page({
   name: 'unspent-convictions-data',
-  bodyProperties: ['convictionType', 'numberOfConvictions', 'currentlyServing', 'safeguarding', 'safeguardingDetail'],
+  bodyProperties: [
+    'convictionType',
+    'numberOfConvictions',
+    'currentlyServing',
+    'convictionDetails',
+    'areOtherDetails',
+    'otherDetails',
+  ],
 })
 export default class UnspentConvictionsData implements TaskListPage {
   personName = nameOrPlaceholderCopy(this.application.person)
@@ -86,13 +94,16 @@ export default class UnspentConvictionsData implements TaskListPage {
       errors.numberOfConvictions = 'Enter the number of convictions of this type'
     }
     if (!this.body.currentlyServing) {
-      errors.currentlyServing = 'Select if they are serving a sentence for any of these convictions'
+      errors.currentlyServing = 'Select yes if they are serving a sentence'
     }
-    if (!this.body.safeguarding) {
-      errors.safeguarding = 'Select if there are any safeguarding details to add, or if it is not known'
+    if (!this.body.convictionDetails) {
+      errors.convictionDetails = 'Enter what the convictions were and when they happened'
     }
-    if (this.body.safeguarding === 'yes' && !this.body.safeguardingDetail) {
-      errors.safeguardingDetail = 'Enter details of the safeguarding measures'
+    if (!this.body.areOtherDetails) {
+      errors.areOtherDetails = 'Select yes if there are other details to add'
+    }
+    if (this.body.areOtherDetails === 'yes' && !this.body.otherDetails) {
+      errors.otherDetails = 'Enter more details'
     }
 
     return errors

--- a/server/form-pages/apply/offences-and-concerns/previous-unspent-convictions/unspentConvictions.test.ts
+++ b/server/form-pages/apply/offences-and-concerns/previous-unspent-convictions/unspentConvictions.test.ts
@@ -14,22 +14,23 @@ describe('UnspentConvictions', () => {
             convictionType: 'stalkingOrHarassment',
             numberOfConvictions: '3',
             currentlyServing: 'yes',
-            safeguarding: 'yes',
-            safeguardingDetail: 'Safeguarding detail',
+            convictionDetails: 'some conviction details',
+            areOtherDetails: 'yes',
+            otherDetails: 'some other detail',
           },
           {
             convictionType: 'arson',
             numberOfConvictions: '2',
             currentlyServing: 'no',
-            safeguarding: 'dontKnow',
-            safeguardingDetail: '',
+            convictionDetails: 'some arson details',
+            areOtherDetails: 'no',
           },
           {
             convictionType: 'drugs',
             numberOfConvictions: '2',
             currentlyServing: 'no',
-            safeguarding: 'no',
-            safeguardingDetail: '',
+            convictionDetails: 'some drug details',
+            areOtherDetails: 'no',
           },
         ],
       },
@@ -56,7 +57,8 @@ describe('UnspentConvictions', () => {
             convictionTypeText: 'Stalking or Harassment',
             numberOfConvictions: '3',
             currentlyServing: 'Yes',
-            safeguarding: 'Safeguarding detail',
+            convictionDetails: 'some conviction details',
+            otherDetails: 'some other detail',
             removeLink: `/applications/${applicationWithData.id}/tasks/previous-unspent-convictions/pages/unspent-convictions-data/0/removeFromList?redirectPage=unspent-convictions`,
           },
           {
@@ -65,7 +67,8 @@ describe('UnspentConvictions', () => {
             convictionTypeText: 'Arson',
             numberOfConvictions: '2',
             currentlyServing: 'No',
-            safeguarding: 'Not known',
+            convictionDetails: 'some arson details',
+            otherDetails: 'No',
             removeLink: `/applications/${applicationWithData.id}/tasks/previous-unspent-convictions/pages/unspent-convictions-data/1/removeFromList?redirectPage=unspent-convictions`,
           },
           {
@@ -74,7 +77,8 @@ describe('UnspentConvictions', () => {
             convictionTypeText: 'Drugs',
             numberOfConvictions: '2',
             currentlyServing: 'No',
-            safeguarding: 'No',
+            convictionDetails: 'some drug details',
+            otherDetails: 'No',
             removeLink: `/applications/${applicationWithData.id}/tasks/previous-unspent-convictions/pages/unspent-convictions-data/2/removeFromList?redirectPage=unspent-convictions`,
           },
         ])
@@ -98,11 +102,11 @@ describe('UnspentConvictions', () => {
         const page = new UnspentConvictions({}, applicationWithData)
         expect(page.response()).toEqual({
           '<strong class="govuk-tag govuk-tag--blue">Stalking or Harassment</strong><p class="govuk-visually-hidden">conviction information</p>':
-            'Number of convictions: 3\r\nActive sentence: Yes\r\nSafeguarding: Safeguarding detail',
+            'Number of convictions: 3\r\nActive sentence: Yes\r\nConviction details: some conviction details\r\nOther details: some other detail',
           '<strong class="govuk-tag govuk-tag--yellow">Arson</strong><p class="govuk-visually-hidden">conviction information</p>':
-            'Number of convictions: 2\r\nActive sentence: No\r\nSafeguarding: Not known',
+            'Number of convictions: 2\r\nActive sentence: No\r\nConviction details: some arson details\r\nOther details: No',
           '<strong class="govuk-tag govuk-tag--custom-brown">Drugs</strong><p class="govuk-visually-hidden">conviction information</p>':
-            'Number of convictions: 2\r\nActive sentence: No\r\nSafeguarding: No',
+            'Number of convictions: 2\r\nActive sentence: No\r\nConviction details: some drug details\r\nOther details: No',
         })
       })
 

--- a/server/form-pages/apply/offences-and-concerns/previous-unspent-convictions/unspentConvictions.ts
+++ b/server/form-pages/apply/offences-and-concerns/previous-unspent-convictions/unspentConvictions.ts
@@ -9,12 +9,13 @@ import { getQuestions } from '../../../utils/questions'
 
 type UnspentConvictionsBody = { convictionsList: string }
 
-type UnspentConvictionsUI = {
+export type UnspentConvictionsUI = {
   convictionTypeTag: string
   convictionTypeText: string
   numberOfConvictions: string
   currentlyServing: string
-  safeguarding: string
+  convictionDetails: string
+  otherDetails: string
   removeLink: string
 }
 
@@ -60,8 +61,9 @@ export default class UnspentConvictions implements TaskListPage {
           convictionTypeTag: this.getOffenceCategoryTag(unspentConviction.convictionType, convictionTypeText),
           convictionTypeText,
           numberOfConvictions: unspentConviction.numberOfConvictions,
-          currentlyServing: this.getCurrentlyServingAnswer(unspentConviction.currentlyServing),
-          safeguarding: this.getSafeguardingAnswer(unspentConviction),
+          currentlyServing: unspentConviction.currentlyServing === 'yes' ? 'Yes' : 'No',
+          convictionDetails: unspentConviction.convictionDetails,
+          otherDetails: unspentConviction.otherDetails || 'No',
           removeLink: `${paths.applications.removeFromList({
             id: application.id,
             task: this.taskName,
@@ -103,9 +105,10 @@ export default class UnspentConvictions implements TaskListPage {
     const response: Record<string, string> = {}
 
     this.unspentConvictions?.forEach(unspentConviction => {
-      const { convictionTypeTag, numberOfConvictions, currentlyServing, safeguarding } = unspentConviction
+      const { convictionTypeTag, numberOfConvictions, currentlyServing, convictionDetails, otherDetails } =
+        unspentConviction
 
-      const unspentConvictionString = `Number of convictions: ${numberOfConvictions}\r\nActive sentence: ${currentlyServing}\r\nSafeguarding: ${safeguarding}`
+      const unspentConvictionString = `Number of convictions: ${numberOfConvictions}\r\nActive sentence: ${currentlyServing}\r\nConviction details: ${convictionDetails}\r\nOther details: ${otherDetails}`
       response[convictionTypeTag] = unspentConvictionString
     })
 
@@ -137,25 +140,5 @@ export default class UnspentConvictions implements TaskListPage {
       default:
         return 'grey'
     }
-  }
-
-  getCurrentlyServingAnswer(answer: Pick<UnspentConvictionsDataBody, 'currentlyServing'>['currentlyServing']): string {
-    if (answer === 'yes') {
-      return 'Yes'
-    }
-
-    return 'No'
-  }
-
-  getSafeguardingAnswer(unspentConviction: UnspentConvictionsDataBody) {
-    if (unspentConviction.safeguardingDetail) {
-      return unspentConviction.safeguardingDetail
-    }
-
-    if (unspentConviction.safeguarding === 'no') {
-      return 'No'
-    }
-
-    return 'Not known'
   }
 }

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -1046,16 +1046,20 @@ export const getQuestions = (name: string) => {
             no: 'No, they have served their sentence',
           },
         },
-        safeguarding: {
-          question: 'Are there any safeguarding details to add about these convictions?',
+        convictionDetails: {
+          question: 'What were the convictions and when did they happen?',
+          hint: 'For example, Actual Bodily Harm on 20 9 2023.',
+        },
+        areOtherDetails: {
+          question: 'Are there any other details about these convictions to add?',
           hint: 'For example, if there is an active restraining order or a child protection arrangement in place.',
           answers: {
-            ...yesNoOrIDontKnow,
-            dontKnow: 'Not known',
+            yes: 'Yes',
+            no: 'No, there are no other details available',
           },
         },
-        safeguardingDetail: {
-          question: 'Enter details of the safeguarding measures',
+        otherDetails: {
+          question: 'Enter the details',
         },
       },
     },

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -1,5 +1,6 @@
 import { QuestionAndAnswer } from '@approved-premises/ui'
 
+import { UnspentConvictionsUI } from '../form-pages/apply/offences-and-concerns/previous-unspent-convictions/unspentConvictions'
 import { applicationFactory, applicationSummaryFactory } from '../testutils/factories'
 
 import {
@@ -10,8 +11,10 @@ import {
   assessmentsTableRows,
   getStatusTag,
   arePreTaskListTasksIncomplete,
+  unspentConvictionsCardRows,
 } from './applicationUtils'
 import submittedApplicationSummary from '../testutils/factories/submittedApplicationSummary'
+import { summaryListItem } from './formUtils'
 
 describe('inProgressApplicationTableRows', () => {
   it('returns an array of applications as table rows', async () => {
@@ -287,5 +290,26 @@ describe('arePreTaskListTasksIncomplete', () => {
     })
 
     expect(arePreTaskListTasksIncomplete(application)).toEqual(true)
+  })
+
+  describe('unspentConvictionsCardRows', () => {
+    it('returns an array of summary list items for an unspent conviction', () => {
+      const conviction = {
+        convictionTypeTag: null,
+        convictionTypeText: null,
+        numberOfConvictions: '2',
+        currentlyServing: 'Yes',
+        convictionDetails: 'some details about the convictions',
+        otherDetails: 'some other details',
+        removeLink: null,
+      } as UnspentConvictionsUI
+
+      expect(unspentConvictionsCardRows(conviction)).toEqual([
+        summaryListItem('Number of convictions of the same type', '2'),
+        summaryListItem('Are they currently serving a sentence for these convictions?', 'Yes'),
+        summaryListItem('What were the convictions and when did they happen?', 'some details about the convictions'),
+        summaryListItem('Are there any other details about these convictions to add?', 'some other details'),
+      ])
+    })
   })
 })

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -3,12 +3,14 @@ import type {
   Cas2v2ApplicationSummary,
   Cas2v2Application,
 } from '@approved-premises/api'
-import type { QuestionAndAnswer, TableRow } from '@approved-premises/ui'
+import type { QuestionAndAnswer, SummaryListItem, TableRow } from '@approved-premises/ui'
+import { UnspentConvictionsUI } from '../form-pages/apply/offences-and-concerns/previous-unspent-convictions/unspentConvictions'
 import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
 import { DateFormats } from './dateUtils'
 import { formatLines } from './viewUtils'
 import { camelCaseToCapitaliseFirstWordAndAddSpaces } from './utils'
+import { summaryListItem } from './formUtils'
 
 export const inProgressApplicationTableRows = (applications: Array<Cas2v2ApplicationSummary>): Array<TableRow> => {
   return applications.map(application => {
@@ -136,4 +138,13 @@ export const arePreTaskListTasksIncomplete = (application: Cas2v2Application): b
     return false
   }
   return true
+}
+
+export const unspentConvictionsCardRows = (unspentConviction: UnspentConvictionsUI): Array<SummaryListItem> => {
+  return [
+    summaryListItem('Number of convictions of the same type', unspentConviction.numberOfConvictions),
+    summaryListItem('Are they currently serving a sentence for these convictions?', unspentConviction.currentlyServing),
+    summaryListItem('What were the convictions and when did they happen?', unspentConviction.convictionDetails),
+    summaryListItem('Are there any other details about these convictions to add?', unspentConviction.otherDetails),
+  ]
 }

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -5,6 +5,7 @@ import {
   convertKeyValuePairToRadioItems,
   convertKeyValuePairToCheckboxItems,
   dateFieldValues,
+  summaryListItem,
 } from './formUtils'
 
 describe('formutils', () => {
@@ -241,6 +242,26 @@ describe('formutils', () => {
           value: context['myField-year'],
         },
       ])
+    })
+  })
+
+  describe('SummaryListItem', () => {
+    const label = 'label'
+    const value = 'test value'
+
+    it('should return a summary list item', () => {
+      expect(summaryListItem(label, value)).toEqual({ key: { text: label }, value: { text: value } })
+      expect(summaryListItem(label, value, 'html')).toEqual({ key: { text: label }, value: { html: value } })
+      expect(summaryListItem(label, value, 'textBlock')).toEqual({
+        key: { text: label },
+        value: { html: `<span class="govuk-summary-list__textblock">${value}</span>` },
+      })
+      expect(summaryListItem(label, undefined)).toEqual({ key: { text: label }, value: { text: undefined } })
+    })
+
+    it('should return undefined if value is falsey and blank suppression enabled', () => {
+      expect(summaryListItem(label, '', 'text')).toEqual({ key: { text: label }, value: { text: '' } })
+      expect(summaryListItem(label, '', 'text', true)).toEqual(undefined)
     })
   })
 })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,5 +1,5 @@
 import * as nunjucks from 'nunjucks'
-import { RadioItem, CheckboxItem, ErrorMessages } from '@approved-premises/ui'
+import { RadioItem, CheckboxItem, ErrorMessages, HtmlItem, TextItem, SummaryListItem } from '@approved-premises/ui'
 
 export const escape = (text: string): string => {
   const escapeFilter = new nunjucks.Environment().getFilter('escape')
@@ -50,4 +50,19 @@ export const dateFieldValues = (fieldName: string, context: Record<string, unkno
       value: context[`${fieldName}-year`],
     },
   ]
+}
+
+export const summaryListItem = (
+  label: string,
+  value: string,
+  renderAs: keyof TextItem | keyof HtmlItem | 'textBlock' = 'text',
+  supressBlank = false,
+): SummaryListItem => {
+  const htmlValue = renderAs === 'textBlock' ? `<span class="govuk-summary-list__textblock">${value}</span>` : value
+  return !supressBlank || value
+    ? {
+        key: { text: label },
+        value: renderAs === 'text' ? { text: value } : { html: htmlValue },
+      }
+    : undefined
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -18,6 +18,7 @@ import {
   assessmentsTableRows,
   arePreTaskListTasksIncomplete,
   prisonApplicationTableRows,
+  unspentConvictionsCardRows,
 } from './applicationUtils'
 import {
   getApplicationTimelineEvents,
@@ -115,4 +116,6 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addGlobal('PhaseBannerUtils', PhaseBannerUtils)
 
   njkEnv.addFilter('assetMap', (url: string) => assetManifest[url] || url)
+
+  njkEnv.addGlobal('unspentConvictionsCardRows', unspentConvictionsCardRows)
 }

--- a/server/views/applications/pages/previous-unspent-convictions/unspent-convictions-data.njk
+++ b/server/views/applications/pages/previous-unspent-convictions/unspent-convictions-data.njk
@@ -8,13 +8,25 @@
 
 {% extends "../layout.njk" %}
 
-{% set safeguardingFollowUpHtml %}
+{% set otherDetailsHintHtml %}
+  <p class="govuk-body govuk-!-margin-bottom-1">For example:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>what happened (excluding names and sensitive information)</li>
+    <li>where it happened (excluding addresses)</li>
+    <li>any weapons used or injuries caused</li>
+  </ul>
+{% endset %}
+
+{% set areOtherDetailsFollowUpHtml %}
   {{
       formPageTextArea(
         {
-          fieldName: "safeguardingDetail",
+          fieldName: "otherDetails",
+          hint: {
+            html: otherDetailsHintHtml
+          },
           label: {
-            text: page.questions.safeguardingDetail.question,
+            text: page.questions.otherDetails.question,
             classes: "govuk-label--s"
           }
         },
@@ -23,60 +35,8 @@
   }}
 {% endset %}
 
-{% set whenIsAConvictionSpentGuidanceHtml %}
-  <p>Most convictions or cautions become ‘spent’ after a specific amount of time. This might be after a few months or years, or straight away.</p>
-
-  <a class="govuk-link" href="https://www.gov.uk/tell-employer-or-college-about-criminal-record/check-your-conviction-caution" target="_blank">Check if the applicant’s convictions or cautions are spent (opens in a new tab).</a>
-{% endset %}
-
-{% set convictionTypesGuidanceHtml %}
-  <p>You only need to add any convictions that are unspent and meet one or more of the following criteria:</p>
-
-  <ul class="govuk-list govuk-list--bullet">
-
-    <li>are relevant to the charges the applicant is being held for</li>
-    <li>
-      relate to any of the following categories:
-      <ul class="govuk-list govuk-list--bullet">
-        <li>arson</li>
-        <li>domestic abuse</li>
-        <li>drugs</li>
-        <li>hate-related attitudes</li>
-        <li>stalking and harassment</li>
-        <li>violence</li>
-        <li>weapons and firearms</li>
-      </ul>
-    </li>
-    <li>might raise concerns towards other adults and children</li>
-  </ul>
-
-  <p>This is because they are relevant to living in shared accommodation.</p>
-{% endset %}
-
 {% set unspentConvictionsGuidanceHtml %}
-  <p>Add any:</p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>active community orders or sentences that the applicant is currently serving</li>
-    <li>past offences for which the applicant has been convicted and has already served the sentence for</li>
-  </ul>
-
-  {{
-    govukDetails({
-      summaryText: "Which types of convictions to add",
-      html: convictionTypesGuidanceHtml
-    })
-  }}
-
-  {{
-    govukDetails({
-      summaryText: "When is a conviction spent?",
-      html: whenIsAConvictionSpentGuidanceHtml
-    })
-  }}
-
-  <p class="govuk-!-font-weight-bold">How to add convictions</p>
-
-  <p>Add any convictions of the same type together. You only need to add details about any  safeguarding measures once.</p>
+ {% include "../../../partials/unspentConvictionsGuidanceDetails.njk" %}
 {% endset %}
 
 {% block content %}
@@ -97,11 +57,23 @@
       <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
 
       {{
-        govukInsetText({
-          html: unspentConvictionsGuidanceHtml,
-          classes: "guidance-panel"
+        govukDetails({
+          summaryText: 'Which types of convictions to add',
+          html: unspentConvictionsGuidanceHtml
         })
       }}
+
+      {{
+        govukDetails({
+          summaryText: 'How to check if a conviction is spent',
+          html: '<p>You can <a class="govuk-link" href="https://www.gov.uk/tell-employer-or-college-about-criminal-record/check-your-conviction-caution" target="_blank">check if the applicant’s convictions or cautions are spent (opens in a new tab).</a></p>',
+          classes: "govuk-!-margin-top-4"
+        })
+      }}
+
+      <h2>How to add convictions</h2>
+
+      <p>Add any convictions of the same type together. You only need to add a summary of convictions of the same type once.</p>
 
       <form id="form" action="{{ paths.applications.appendToList({ id: applicationId, task: page.taskName, page: page.name }) }}?_method=PUT" method="post" autocomplete="off">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
@@ -166,33 +138,42 @@
         }}
 
         {{
+          formPageTextArea(
+            {
+              fieldName: "convictionDetails",
+              hint: {
+                html: page.questions.convictionDetails.hint
+              },
+              label: {
+                text: page.questions.convictionDetails.question,
+                classes: "govuk-label--m"
+              }
+            },
+            fetchContext()
+          )
+        }}
+
+        {{
             formPageRadios(
               {
-                fieldName: "safeguarding",
+                fieldName: "areOtherDetails",
                 fieldset: {
                   legend: {
-                    text: page.questions.safeguarding.question,
+                    text: page.questions.areOtherDetails.question,
                     classes: "govuk-fieldset__legend--m"
                   }
-                },
-                hint: {
-                  text: page.questions.safeguarding.hint
                 },
                 items: [
                   {
                     value: "yes",
-                    text: page.questions.safeguarding.answers.yes,
+                    text: page.questions.areOtherDetails.answers.yes,
                     conditional: {
-                      html: safeguardingFollowUpHtml
+                      html: areOtherDetailsFollowUpHtml
                     }
                   },
                   {
                     value: "no",
-                    text: page.questions.safeguarding.answers.no
-                  },
-                  {
-                    value: "dontKnow",
-                    text: page.questions.safeguarding.answers.dontKnow
+                    text: page.questions.areOtherDetails.answers.no
                   }
                 ]
               },

--- a/server/views/applications/pages/previous-unspent-convictions/unspent-convictions.njk
+++ b/server/views/applications/pages/previous-unspent-convictions/unspent-convictions.njk
@@ -27,32 +27,7 @@
               ]
             }
           },
-          rows: [
-            {
-              key: {
-                text: 'Number of convictions of the same type'
-              },
-              value: {
-                text: unspentConviction.numberOfConvictions
-              }
-            },
-            {
-              key: {
-                text: 'Are they currently serving a sentence for these convictions?'
-              },
-              value: {
-                text: unspentConviction.currentlyServing
-              }
-            },
-            {
-              key: {
-                text: 'Are there any safeguarding details to add about these convictions?'
-              },
-              value: {
-                text: unspentConviction.safeguarding
-              }
-            }
-          ]
+          rows: unspentConvictionsCardRows(unspentConviction)
         })
       }}
     {% endfor %}

--- a/server/views/partials/unspentConvictionsGuidanceDetails.njk
+++ b/server/views/partials/unspentConvictionsGuidanceDetails.njk
@@ -1,0 +1,48 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+<div class="nhsuk-do-dont-list govuk-!-margin-top-4">
+  <p class="nhsuk-do-dont-list__label govuk-!-font-size-19 govuk-!-font-weight-bold">Add any unspent convictions that meet one or more of the following criteria:</p>
+  <ul class="nhsuk-list nhsuk-list--tick" role="list">
+    <li> <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" aria-hidden="true" width="34" height="34">
+        <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12" stroke="#007f3b"></path>
+      </svg>are relevant to the charges the applicant is being held for
+    </li>
+    <li> <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" aria-hidden="true" width="34" height="34">
+        <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12" stroke="#007f3b"></path>
+      </svg>relate to the following categories:
+      <ul>
+        <li>arson</li>
+        <li>domestic abuse</li>
+        <li>drugs</li>
+        <li>hate-related attitudes</li>
+        <li>stalking and harassment</li>
+        <li>violence</li>
+        <li>weapons and firearms</li>
+      </ul>
+    </li>
+    <li> <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" aria-hidden="true" width="34" height="34">
+        <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12" stroke="#007f3b"></path>
+      </svg>might raise concerns towards other adults and children
+    </li>
+    <li> <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" aria-hidden="true" width="34" height="34">
+        <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12" stroke="#007f3b"></path>
+      </svg>where the applicant is currently serving a sentence
+    </li>
+  </ul>
+</div>
+
+<div class="nhsuk-do-dont-list govuk-!-margin-top-4">
+  <p class="nhsuk-do-dont-list__label govuk-!-font-size-19 govuk-!-font-weight-bold">Do not add any:</p>
+  <ul class="nhsuk-list nhsuk-list--cross" role="list">
+    <li> <svg class="nhsuk-icon nhsuk-icon__cross" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
+        <path d="M17 18.5c-.4 0-.8-.1-1.1-.4l-10-10c-.6-.6-.6-1.6 0-2.1.6-.6 1.5-.6 2.1 0l10 10c.6.6.6 1.5 0 2.1-.3.3-.6.4-1 .4z" fill="#d5281b"></path>
+        <path d="M7 18.5c-.4 0-.8-.1-1.1-.4-.6-.6-.6-1.5 0-2.1l10-10c.6-.6 1.5-.6 2.1 0 .6.6.6 1.5 0 2.1l-10 10c-.3.3-.6.4-1 .4z" fill="#d5281b"></path>
+      </svg><span class="govuk-!-font-weight-bold">spent</span> convictions
+    </li>
+    <li> <svg class="nhsuk-icon nhsuk-icon__cross" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
+        <path d="M17 18.5c-.4 0-.8-.1-1.1-.4l-10-10c-.6-.6-.6-1.6 0-2.1.6-.6 1.5-.6 2.1 0l10 10c.6.6.6 1.5 0 2.1-.3.3-.6.4-1 .4z" fill="#d5281b"></path>
+        <path d="M7 18.5c-.4 0-.8-.1-1.1-.4-.6-.6-.6-1.5 0-2.1l10-10c.6-.6 1.5-.6 2.1 0 .6.6.6 1.5 0 2.1l-10 10c-.3.3-.6.4-1 .4z" fill="#d5281b"></path>
+      </svg>unspent convictions that do not meet any of the criteria listed
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/CBA-688

# Changes in this PR

- adds new guidance to the unspent convictions 'data' page
- updates the questions on this page
- makes changes to the unspent convictions page to render the new data fields

## Screenshots of UI changes

### Before
Unspent convictions 'data' page
![Screenshot 2025-06-20 at 12 09 34](https://github.com/user-attachments/assets/1b3ccde8-4939-4385-a9b3-9fc51d7cc455)

Unspent convictions page
![Screenshot 2025-06-20 at 12 09 06](https://github.com/user-attachments/assets/85818765-e65e-49b3-9564-0b4a1dde37a8)

Check your answers
![Screenshot 2025-06-20 at 12 08 52](https://github.com/user-attachments/assets/00c7f583-06cb-48e4-8cb6-0d2c9c10fcc1)

### After

Unspent convictions 'data' page
![Screenshot 2025-06-20 at 12 06 00](https://github.com/user-attachments/assets/40862356-2c19-4bb0-802e-19b4356289e7)

Unspent convictions page
![Screenshot 2025-06-20 at 12 06 30](https://github.com/user-attachments/assets/595ce00c-f586-495b-8182-5fc86edfde88)

Check your answers
![Screenshot 2025-06-20 at 12 07 15](https://github.com/user-attachments/assets/09e51e1a-676c-40b7-9fd8-8aee85f5f7d4)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
