### PR TITLE
Remove OASys information source guard

### DIFF
--- a/server/form-pages/apply/health-needs/health-needs/informationSources.ts
+++ b/server/form-pages/apply/health-needs/health-needs/informationSources.ts
@@ -100,10 +100,6 @@ export default class InformationSources implements TaskListPage {
     let sourceList = ''
 
     sourcesArr.forEach(source => {
-      if (this.isOasys(source)) {
-        sourceList += `Previous or current OASys\r\n`
-        return
-      }
       sourceList += `${this.questions.informationSources.answers[source]}\r\n`
     })
 
@@ -119,9 +115,5 @@ export default class InformationSources implements TaskListPage {
     response[this.questions.otherSourcesDetail.question] = this.body.otherSourcesDetail ?? ''
 
     return response
-  }
-
-  isOasys(value: string): value is typeof value {
-    return value === 'oasys'
   }
 }

--- a/server/form-pages/apply/offences-and-concerns/risk-information/informationSources.ts
+++ b/server/form-pages/apply/offences-and-concerns/risk-information/informationSources.ts
@@ -99,10 +99,6 @@ export default class InformationSources implements TaskListPage {
 
     let sourceList = ''
     sourcesArr.forEach(source => {
-      if (this.isOasys(source)) {
-        sourceList += `Previous or current OASys\r\n`
-        return
-      }
       sourceList += `${this.questions.informationSources.answers[source]}\r\n`
     })
 
@@ -118,9 +114,5 @@ export default class InformationSources implements TaskListPage {
     response[this.questions.otherSourcesDetail.question] = this.body.otherSourcesDetail ?? ''
 
     return response
-  }
-
-  isOasys(value: string): value is typeof value {
-    return value === 'oasys'
   }
 }


### PR DESCRIPTION
We added this guard when we moved from a single OASys information source to two separate ones, in case any in progress applications had selected that option. The guard ensures that that OASys option would render in CYA and the submitted applications views.

It has been two weeks since we implemented that change and it is now unlikely that any genuinely in progress applications are using that option, so we can remove the guard.

# Context

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
