### PR TITLE
CBA-726 add sub navigation to applications dashboards

### DIFF
--- a/integration_tests/pages/apply/applicationListPage.ts
+++ b/integration_tests/pages/apply/applicationListPage.ts
@@ -1,0 +1,43 @@
+import { Cas2v2Application as Application, Cas2v2ApplicationSummary } from '@approved-premises/api'
+import Page from '../page'
+import paths from '../../../server/paths/apply'
+
+export default class ApplicationListPage extends Page {
+  constructor(
+    private readonly applications: Array<Cas2v2ApplicationSummary>,
+    name: string,
+  ) {
+    super('Your CAS-2 applications', name)
+  }
+
+  static visit(applications: Array<Cas2v2ApplicationSummary>): ApplicationListPage {
+    cy.visit(paths.applications.index.pattern)
+
+    return new ApplicationListPage(applications, applications[0]?.personName)
+  }
+
+  shouldShowInProgressApplications(): void {
+    this.shouldShowApplications(this.applications, true)
+  }
+
+  shouldShowSubmittedApplications(): void {
+    cy.get('a').contains('Submitted').click()
+    this.shouldShowApplications(this.applications)
+  }
+
+  shouldShowPrisonTab(): void {
+    cy.contains(`All prison bail applications`).should('have.attr', 'href', paths.applications.prison.pattern)
+  }
+
+  shouldNotShowPrisonTab(): void {
+    cy.contains(`All prison bail applications`).should('not.exist')
+  }
+
+  clickApplication(application: Application) {
+    cy.get(`a[data-cy-id="${application.id}"]`).click()
+  }
+
+  clickCancel = (): void => {
+    cy.get('a').contains('Cancel').click()
+  }
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -191,4 +191,23 @@ export default abstract class Page {
       this.checkTermAndDescription('CRN from NDelius', person.crn)
     })
   }
+
+  shouldShowApplications(applications: Array<Cas2v2ApplicationSummary>, inProgress = false): void {
+    applications.forEach(application => {
+      const { personName } = application
+      cy.contains(personName)
+        .should(
+          'have.attr',
+          'href',
+          inProgress
+            ? paths.applications.show({ id: application.id })
+            : paths.applications.overview({ id: application.id }),
+        )
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('th').eq(0).contains(personName)
+        })
+    })
+  }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -8,7 +8,6 @@ import {
 import errorLookups from '../../server/i18n/en/errors.json'
 import { DateFormats } from '../../server/utils/dateUtils'
 import paths from '../../server/paths/apply'
-import { camelCaseToCapitaliseFirstWordAndAddSpaces } from '../../server/utils/utils'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -69,27 +68,6 @@ export default abstract class Page {
 
       cy.get('.govuk-error-summary').should('contain', errorMessagesLookup)
       cy.get(`[data-cy-error-${field}]`).should('contain', errorMessagesLookup)
-    })
-  }
-
-  shouldShowPrisonBailApplications(applications: Array<Cas2v2ApplicationSummary>): void {
-    applications.forEach(application => {
-      const { personName, nomsNumber, createdByUserName, crn, prisonCode, applicationOrigin } = application
-      const statusLabel = application.latestStatusUpdate?.label
-
-      cy.contains(personName)
-        .should('have.attr', 'href', paths.applications.overview({ id: application.id }))
-        .parent()
-        .parent()
-        .within(() => {
-          cy.get('th').eq(0).contains(personName)
-          cy.get('td').eq(0).should('contain.text', nomsNumber)
-          cy.get('td').eq(1).should('contain.text', prisonCode)
-          cy.get('td').eq(2).should('contain.text', crn)
-          cy.get('td').eq(3).should('contain.text', createdByUserName)
-          cy.get('td').eq(4).should('contain.text', camelCaseToCapitaliseFirstWordAndAddSpaces(applicationOrigin))
-          cy.get('td').eq(5).should('contain.text', statusLabel)
-        })
     })
   }
 

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -72,7 +72,7 @@ export default abstract class Page {
     })
   }
 
-  shouldShowPrisonApplications(applications: Array<Cas2v2ApplicationSummary>): void {
+  shouldShowPrisonBailApplications(applications: Array<Cas2v2ApplicationSummary>): void {
     applications.forEach(application => {
       const { personName, nomsNumber, createdByUserName, crn, prisonCode, applicationOrigin } = application
       const statusLabel = application.latestStatusUpdate?.label

--- a/integration_tests/tests/apply/dashboard.cy.ts
+++ b/integration_tests/tests/apply/dashboard.cy.ts
@@ -1,0 +1,100 @@
+//  Feature: Referrer views list of existing applications
+//    So that I can view my existing applications
+//    As a referrer
+//    I want to see them listed on an application dashboard
+//
+//  Scenario: show in progress applications
+//    Given I am logged in
+//    And there are in progress applications in the database
+//    When I visit the applications page
+//    Then I should see all of the in progress applications
+//
+//  Scenario: show submitted applications
+//    Given I am logged in
+//    And there are submitted applications in the database
+//    When I visit the submitted applications tab
+//    Then I should see all of my submitted applications
+//
+//  Scenario: see prison dashboard
+//    Given I am logged in as a prison bail referrer
+//    Then I see a tab to view prison bail applications
+//
+//  Scenario: don't see prison dashboard
+//    Given I am logged in as a court bail referrer
+//    Then I should not see a tab to view prison bail applications
+
+import ApplicationListPage from '../../pages/apply/applicationListPage'
+import { applicationSummaryFactory } from '../../../server/testutils/factories'
+
+context('Applications dashboard as a prison bail referrer', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn', { roles: ['ROLE_CAS2_PRISON_BAIL_REFERRER'] })
+    cy.task('stubAuthUser')
+
+    // Given I am logged in as a prison bail referrer
+    cy.signIn()
+  })
+
+  //  Scenario: show in progress applications
+  // ----------------------------------------------
+  it('shows in progress applications', () => {
+    // There are applications in the database
+    const inProgressApplications = applicationSummaryFactory.buildList(5, {
+      status: 'inProgress',
+      latestStatusUpdate: null,
+    })
+
+    cy.task('stubApplications', inProgressApplications)
+
+    // I visit the applications page
+    const page = ApplicationListPage.visit(inProgressApplications)
+
+    // I should see all of the in progress applications
+    page.shouldShowInProgressApplications()
+  })
+
+  //  Scenario: show submitted applications
+  it('shows submitted applications', () => {
+    // There are applications in the database
+    const submittedApplications = applicationSummaryFactory.buildList(5, {
+      status: 'submitted',
+    })
+    cy.task('stubApplications', submittedApplications)
+
+    // I visit the submitted applications tab
+    const page = ApplicationListPage.visit(submittedApplications)
+
+    // I should see all the in progress applications
+    page.shouldShowSubmittedApplications()
+  })
+
+  //  Scenario: see prison dashboard
+  it('shows prison dashboard tab', () => {
+    cy.task('stubApplications', [])
+
+    // Then I see a tab for my prison's applications
+    const page = ApplicationListPage.visit([])
+    page.shouldShowPrisonTab()
+  })
+})
+
+context('Applications dashboard as a court bail referrer', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn', { roles: ['ROLE_CAS2_COURT_BAIL_REFERRER'] })
+    cy.task('stubAuthUser')
+
+    // Given I am logged in as a court bail referrer
+    cy.signIn()
+  })
+
+  //  Scenario: don't see prison dashboard
+  it('does not show prison dashboard tab', () => {
+    cy.task('stubApplications', [])
+
+    // Then I should not see a tab to view prison bail applications
+    const page = ApplicationListPage.visit([])
+    page.shouldNotShowPrisonTab()
+  })
+})

--- a/integration_tests/tests/apply/prison-bail-applications.cy.ts
+++ b/integration_tests/tests/apply/prison-bail-applications.cy.ts
@@ -1,13 +1,13 @@
 //  Feature: referrer views prison applications
-//    So that I can see recently created applications for my prison
+//    So that I can see recently created prison bail applications
 //    So that I can manage applications
 //
 //  Scenario: viewing the prison applications page as a referrer
 //      Given I am logged in as a prison bail referrer
-//      And there are submitted applications for my prison in the database
+//      And there are submitted prison bail applications in the database
 //      When I visit the prison applications page
 //      Then I can see the prison applications page
-//      And I can see a list of applications for my prison
+//      And I can see a list of prison bail applications
 
 import { applicationSummaryFactory } from '../../../server/testutils/factories'
 import PrisonApplicationsPage from '../../pages/apply/prisonApplicationsPage'
@@ -17,15 +17,14 @@ context('Prison applications', () => {
   //  Scenario: viewing the home page as a referrer
   it('displays the prison applications page', () => {
     // Given I am logged in as a prison bail referrer
-    const prisonCode = 'ABC'
     cy.task('stubSignIn', { roles: ['ROLE_CAS2_PRISON_BAIL_REFERRER'] })
-    cy.task('stubAuthUser', { activeCaseLoadId: prisonCode })
+    cy.task('stubAuthUser')
 
     cy.signIn()
 
-    // And there are submitted applications for my prison in the database
-    const prisonApplications = applicationSummaryFactory.buildList(3)
-    cy.task('stubApplicationOrigin', { applications: prisonApplications, prisonCode })
+    // And there are submitted prison bail applications in the database
+    const prisonApplications = applicationSummaryFactory.buildList(3, { applicationOrigin: 'prisonBail' })
+    cy.task('stubApplicationOrigin', { applications: prisonApplications })
 
     // When I visit the prison applications page
     PrisonApplicationsPage.visit()
@@ -35,7 +34,7 @@ context('Prison applications', () => {
 
     const prisonApplicationsPage = new PrisonApplicationsPage()
 
-    // And I can see a list of applications for my prison
-    prisonApplicationsPage.shouldShowPrisonApplications(prisonApplications)
+    // And I can see a list of prison bail applications
+    prisonApplicationsPage.shouldShowPrisonBailApplications(prisonApplications)
   })
 })

--- a/integration_tests/tests/apply/prison-bail-applications.cy.ts
+++ b/integration_tests/tests/apply/prison-bail-applications.cy.ts
@@ -35,6 +35,6 @@ context('Prison applications', () => {
     const prisonApplicationsPage = new PrisonApplicationsPage()
 
     // And I can see a list of prison bail applications
-    prisonApplicationsPage.shouldShowPrisonBailApplications(prisonApplications)
+    prisonApplicationsPage.shouldShowApplications(prisonApplications)
   })
 })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -81,10 +81,21 @@ describe('applicationsController', () => {
   })
 
   describe('index', () => {
+    const priorConfigFlags = config.flags
+
+    afterAll(() => {
+      config.flags = priorConfigFlags
+    })
+
     it('renders existing applications', async () => {
+      response = createMock<Response>({
+        locals: { user: { userRoles: ['CAS2_PRISON_BAIL_REFERRER'] } },
+      })
       ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
         return { errors: {}, errorSummary: [], userInput: {} }
       })
+
+      config.flags.enablePrisonDashboard = true
 
       const requestHandler = applicationsController.index()
 
@@ -95,6 +106,7 @@ describe('applicationsController', () => {
         errorSummary: [],
         applications,
         pageHeading: 'Applications',
+        showPrisonDashboard: true,
       })
     })
   })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -17,6 +17,7 @@ import { getPaginationDetails } from '../../utils/getPaginationDetails'
 import { nameOrPlaceholderCopy } from '../../utils/utils'
 import { buildDocument } from '../../utils/applications/documentUtils'
 import { hasRole } from '../../utils/userUtils'
+import config from '../../config'
 
 export default class ApplicationsController {
   constructor(
@@ -32,12 +33,16 @@ export default class ApplicationsController {
 
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
+      const showPrisonDashboard =
+        hasRole(res.locals.user.userRoles, 'CAS2_PRISON_BAIL_REFERRER') && config.flags.enablePrisonDashboard
+
       return res.render('applications/index', {
         errors,
         errorSummary,
         ...userInput,
         applications,
         pageHeading: 'Applications',
+        showPrisonDashboard,
       })
     }
   }

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -1,3 +1,4 @@
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
@@ -29,6 +30,22 @@
       {% endif %}
 
       {{ showErrorSummary(errorSummary) }}
+
+      {% if showPrisonDashboard %}
+
+        {{ mojSubNavigation({
+          label: 'Sub navigation',
+          items: [{
+            text: 'Your applications',
+            href: paths.applications.index(),
+            active: true
+          }, {
+            text: "All prison bail applications",
+            href: paths.applications.prison()
+          }]
+        }) }}
+
+      {% endif %}
 
       {{ govukTabs({
         items: [

--- a/server/views/applications/overview.njk
+++ b/server/views/applications/overview.njk
@@ -19,7 +19,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.applications.index() + '#submitted'
+    href: paths.applications.index()
   }) }}
 {% endblock %}
 

--- a/server/views/applications/prison-applications.njk
+++ b/server/views/applications/prison-applications.njk
@@ -1,3 +1,4 @@
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "../partials/table.njk" import applicationsTable %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
@@ -8,7 +9,19 @@
 
 {% block content %}
 
-<h1>All CAS-2 prison bail applications</h1>
+  <h1 class="govuk-heading-l">All CAS-2 prison bail applications</h1>
+
+  {{ mojSubNavigation({
+    label: 'Sub navigation',
+    items: [{
+      text: 'Your applications',
+      href: paths.applications.index()
+    }, {
+      text: "All prison bail applications",
+      href: paths.applications.prison(),
+      active: true
+    }]
+  }) }}
 
   {{applicationsTable(
     "",


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/CBA-726

# Changes in this PR

- adds sub navigation for prison bail referrers to navigate between the prison bail dashboard and their applications dashboard (for now this is behind a feature flag)
- adds integration tests for applications dashboard

## Screenshots of UI changes

### Before

<img width="1108" height="290" alt="Screenshot 2025-07-21 at 11 40 49" src="https://github.com/user-attachments/assets/f637cfba-465b-4b6c-be75-5e3b0a3fda95" />

<img width="807" height="552" alt="Screenshot 2025-07-21 at 11 40 59" src="https://github.com/user-attachments/assets/ce217ce7-279f-46bc-896b-e041a879fff4" />

### After
<img width="814" height="570" alt="Screenshot 2025-07-21 at 11 39 03" src="https://github.com/user-attachments/assets/a0a8c28e-9bfe-4958-b762-5e7b6a11fec9" />
<img width="1121" height="454" alt="Screenshot 2025-07-21 at 11 39 19" src="https://github.com/user-attachments/assets/afe7fb1a-ab4a-480d-9593-2ae3b0777363" />

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
