### PR TITLE
Added SQS variables to test helm chart to fix test deployment

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -18,6 +18,9 @@ generic-service:
     ENVIRONMENT_NAME: test
     IN_MAINTENANCE_MODE: false
     PLANNED_MAINTENANCE_BANNER: false
+    # required so hmpps-audit-client doesn't raise an error
+    AUDIT_SQS_QUEUE_URL: ""
+    AUDIT_SQS_QUEUE_NAME: ""
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises


### PR DESCRIPTION
# Context

Related to the CAS3 ticket https://dsdmoj.atlassian.net/browse/FM-426

The issue was a consequence of the audit logging we updated recently, as the environment variable `get` function in the `hmpps-audit-client` had different logic that was throwing an exception if `NODE_ENV` was set to `production` and the environment variables for the SQS variables weren't set