### PR TITLE
Add preventDoubleClick to buttons in offence and conviction pages

### DIFF
--- a/server/views/applications/pages/alleged-offences/alleged-offence-data.njk
+++ b/server/views/applications/pages/alleged-offences/alleged-offence-data.njk
@@ -107,14 +107,16 @@
           {{ govukButton({
             id: "add-another",
             text: "Add another alleged offence",
-            classes: "govuk-button--secondary govuk-!-margin-top-8 govuk-!-margin-bottom-4"
+            classes: "govuk-button--secondary govuk-!-margin-top-8 govuk-!-margin-bottom-4",
+            preventDoubleClick: true
           }) }}
         </div>
 
         {% block button %}
           <div class="govuk-button-group">
             {{ govukButton({
-                  text: "Save and continue"
+                  text: "Save and continue",
+                  preventDoubleClick: true
               }) }}
 
             {%if page.hasPreviouslySavedAnAllegedOffence %}

--- a/server/views/applications/pages/previous-unspent-convictions/unspent-convictions-data.njk
+++ b/server/views/applications/pages/previous-unspent-convictions/unspent-convictions-data.njk
@@ -184,7 +184,8 @@
         {% block button %}
           <div class="govuk-button-group">
             {{ govukButton({
-                  text: "Save and continue"
+                  text: "Save and continue",
+                  preventDoubleClick: true
               }) }}
             {%if page.hasPreviouslySavedAnUnspentConviction %}
               <a class="govuk-link" href="{{ paths.applications.pages.show({ id: applicationId, task: page.taskName, page: 'unspent-convictions' }) }}">


### PR DESCRIPTION
# Context

This fixes an [issue](https://mojdt.slack.com/archives/C08KN9XMRUK/p1775807702409859) where the user could double click the add button causing an error to be thrown.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
