### PR TITLE
Refactor restClient to use generics

### DIFF
--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -18,20 +18,18 @@ export default class ApplicationClient {
   }
 
   async find(applicationId: string): Promise<Application> {
-    return (await this.restClient.get({
-      path: paths.applications.show({ id: applicationId }),
-    })) as Application
+    return this.restClient.get<Application>({ path: paths.applications.show({ id: applicationId }) })
   }
 
   async create(crn: string, applicationOrigin: ApplicationOrigin): Promise<Application> {
-    return (await this.restClient.post({
+    return this.restClient.post<Application>({
       path: paths.applications.new.pattern,
       data: { crn: crn.trim(), applicationOrigin },
-    })) as Application
+    })
   }
 
   async all(): Promise<Array<Cas2v2ApplicationSummary>> {
-    return (await this.restClient.get({ path: paths.applications.index.pattern })) as Array<Cas2v2ApplicationSummary>
+    return this.restClient.get<Array<Cas2v2ApplicationSummary>>({ path: paths.applications.index.pattern })
   }
 
   async getAllByPrison(prisonCode: string, pageNumber: number): Promise<PaginatedResponse<Cas2v2ApplicationSummary>> {

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -15,16 +15,14 @@ export default class AssessmentClient {
   }
 
   async find(assessmentId: string): Promise<Cas2v2Assessment> {
-    return (await this.restClient.get({
-      path: paths.assessments.show({ id: assessmentId }),
-    })) as Cas2v2Assessment
+    return this.restClient.get<Cas2v2Assessment>({ path: paths.assessments.show({ id: assessmentId }) })
   }
 
   async update(assessmentId: string, updateData: UpdateCas2v2Assessment): Promise<Cas2v2Assessment> {
-    return (await this.restClient.put({
+    return this.restClient.put<Cas2v2Assessment>({
       path: paths.assessments.update({ id: assessmentId }),
       data: updateData,
-    })) as Cas2v2Assessment
+    })
   }
 
   async updateStatus(assessmentId: string, newStatus: AssessmentStatusUpdate): Promise<void> {

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -20,6 +20,6 @@ export default class HmppsAuthClient {
 
   getUser(token: string): Promise<User> {
     logger.info(`Getting user details: calling HMPPS Auth`)
-    return HmppsAuthClient.restClient(token).get({ path: '/api/user/me' }) as Promise<User>
+    return HmppsAuthClient.restClient(token).get<User>({ path: '/api/user/me' })
   }
 }

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -15,29 +15,17 @@ export default class PersonClient {
     const encodedNomsNumber = encodeURIComponent(nomsNumber)
     const path = paths.people.searchByPrisonNumber({ nomsNumber: encodedNomsNumber })
 
-    const response = await this.restClient.get({
-      path,
-    })
-
-    return response as FullPerson
+    return this.restClient.get<FullPerson>({ path })
   }
 
   async searchByCrn(crn: string): Promise<FullPerson> {
     const encodedCrn = encodeURIComponent(crn)
     const path = `${paths.people.searchByCrn({ crn: encodedCrn })}`
 
-    const response = await this.restClient.get({
-      path,
-    })
-
-    return response as FullPerson
+    return this.restClient.get<FullPerson>({ path })
   }
 
   async risks(crn: string): Promise<PersonRisks> {
-    const response = await this.restClient.get({
-      path: paths.people.risks.show({ crn }),
-    })
-
-    return response as PersonRisks
+    return this.restClient.get<PersonRisks>({ path: paths.people.risks.show({ crn }) })
   }
 }

--- a/server/data/referenceDataClient.ts
+++ b/server/data/referenceDataClient.ts
@@ -12,7 +12,6 @@ export default class ReferenceDataClient {
 
   async getApplicationStatuses(): Promise<Array<ApplicationStatus>> {
     const path = paths.referenceData.applicationStatuses({})
-
-    return (await this.restClient.get({ path })) as Array<ApplicationStatus>
+    return this.restClient.get<Array<ApplicationStatus>>({ path })
   }
 }

--- a/server/data/reportClient.ts
+++ b/server/data/reportClient.ts
@@ -16,11 +16,6 @@ export default class ReportClient {
     const filename = `cas2-${name}-report.xlsx`
     response.set('Content-Disposition', `attachment; filename="${filename}"`)
 
-    await this.restClient.pipe(
-      {
-        path: paths.reports.show({ name }),
-      },
-      response,
-    )
+    await this.restClient.pipe({ path: paths.reports.show({ name }) }, response)
   }
 }

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -59,18 +59,18 @@ export default class RestClient {
     return this.config.timeout
   }
 
-  async put(request: PutRequest = {}): Promise<unknown> {
-    return this.postOrPut('put', request)
+  async put<T = unknown>(request: PutRequest = {}): Promise<T> {
+    return this.postOrPut<T>('put', request)
   }
 
-  async post(request: PostRequest = {}): Promise<unknown> {
-    return this.postOrPut('post', request)
+  async post<T = unknown>(request: PostRequest = {}): Promise<T> {
+    return this.postOrPut<T>('post', request)
   }
 
-  private async postOrPut(
+  private async postOrPut<T = unknown>(
     method: 'post' | 'put',
     { path = null, headers = {}, responseType = '', data = {}, raw = false }: PutRequest | PostRequest = {},
-  ): Promise<unknown> {
+  ): Promise<T> {
     logger.info(`${method} using user credentials: calling ${this.name}: ${path}`)
     try {
       const request =
@@ -85,7 +85,7 @@ export default class RestClient {
         .responseType(responseType)
         .timeout(this.timeoutConfig())
 
-      return raw ? result : result.body
+      return (raw ? result : result.body) as T
     } catch (error) {
       const sanitisedError = sanitiseError(error)
       logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'PUT'`)
@@ -93,7 +93,13 @@ export default class RestClient {
     }
   }
 
-  async get({ path = null, query = '', headers = {}, responseType = '', raw = false }: GetRequest): Promise<unknown> {
+  async get<T = unknown>({
+    path = null,
+    query = '',
+    headers = {},
+    responseType = '',
+    raw = false,
+  }: GetRequest): Promise<T> {
     logger.info(`Get using user credentials: calling ${this.name}: ${path} ${query}`)
     try {
       const result = await superagent
@@ -110,7 +116,7 @@ export default class RestClient {
         .responseType(responseType)
         .timeout(this.timeoutConfig())
 
-      return raw ? result : result.body
+      return (raw ? result : result.body) as T
     } catch (error) {
       const sanitisedError = sanitiseError(error)
       logger.warn({ ...sanitisedError, query }, `Error calling ${this.name}, path: '${path}', verb: 'GET'`)

--- a/server/data/submittedApplicationClient.ts
+++ b/server/data/submittedApplicationClient.ts
@@ -24,15 +24,13 @@ export default class SubmittedApplicationClient {
   }
 
   async find(applicationId: string): Promise<SubmittedApplication> {
-    return (await this.restClient.get({
-      path: paths.submissions.show({ id: applicationId }),
-    })) as SubmittedApplication
+    return this.restClient.get<SubmittedApplication>({ path: paths.submissions.show({ id: applicationId }) })
   }
 
   async addNote(assessmentId: string, newNote: string): Promise<Cas2v2ApplicationNote> {
-    return (await this.restClient.post({
+    return this.restClient.post<Cas2v2ApplicationNote>({
       path: paths.assessments.applicationNotes.create({ id: assessmentId }),
       data: { note: newNote },
-    })) as Cas2v2ApplicationNote
+    })
   }
 }

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -20,17 +20,13 @@ export default class ApplicationService {
   ): Promise<Cas2v2Application> {
     const applicationClient = this.applicationClientFactory(token)
 
-    const application = await applicationClient.create(crn, applicationOrigin)
-
-    return application
+    return applicationClient.create(crn, applicationOrigin)
   }
 
   async findApplication(token: string, id: string): Promise<Cas2v2Application> {
     const applicationClient = this.applicationClientFactory(token)
 
-    const application = await applicationClient.find(id)
-
-    return application
+    return applicationClient.find(id)
   }
 
   async getAllForLoggedInUser(token: string): Promise<GroupedApplications> {
@@ -38,12 +34,12 @@ export default class ApplicationService {
 
     const allApplications = await applicationClient.all()
 
-    const result = {
+    const result: GroupedApplications = {
       inProgress: [],
       submitted: [],
-    } as GroupedApplications
+    }
 
-    allApplications.map(async application => {
+    allApplications.forEach(application => {
       if (application.status === 'inProgress') {
         result.inProgress.push(application)
       } else if (application.status === 'submitted') {
@@ -61,9 +57,7 @@ export default class ApplicationService {
   ): Promise<PaginatedResponse<Cas2v2ApplicationSummary>> {
     const applicationClient = this.applicationClientFactory(token)
 
-    const applications = await applicationClient.getAllByPrison(prisonCode, pageNumber)
-
-    return applications
+    return applicationClient.getAllByPrison(prisonCode, pageNumber)
   }
 
   async getAllByOrigin(
@@ -73,6 +67,7 @@ export default class ApplicationService {
     pageNumber: number = 1,
   ): Promise<PaginatedResponse<Cas2v2ApplicationSummary>> {
     const applicationClient = this.applicationClientFactory(token)
+
     return applicationClient.getAllByOrigin(applicationOrigin, crnOrNomsNumber, pageNumber)
   }
 

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -1,7 +1,7 @@
 import {
   Cas2v2Assessment,
-  UpdateCas2v2Assessment,
   Cas2v2AssessmentStatusUpdate as AssessmentStatusUpdate,
+  UpdateCas2v2Assessment,
 } from '@approved-premises/api'
 import { AssessmentClient, RestClientBuilder } from '../data'
 
@@ -11,9 +11,7 @@ export default class AssessmentService {
   async findAssessment(token: string, assessmentId: string): Promise<Cas2v2Assessment> {
     const assessmentClient = this.assessmentClientFactory(token)
 
-    const assessment = await assessmentClient.find(assessmentId)
-
-    return assessment
+    return assessmentClient.find(assessmentId)
   }
 
   async updateAssessment(
@@ -23,14 +21,12 @@ export default class AssessmentService {
   ): Promise<Cas2v2Assessment> {
     const assessmentClient = this.assessmentClientFactory(token)
 
-    const assessment = await assessmentClient.update(assessmentId, updateData)
-
-    return assessment
+    return assessmentClient.update(assessmentId, updateData)
   }
 
   async updateAssessmentStatus(token: string, assessmentId: string, newStatus: AssessmentStatusUpdate): Promise<void> {
     const assessmentClient = this.assessmentClientFactory(token)
 
-    await assessmentClient.updateStatus(assessmentId, newStatus)
+    return assessmentClient.updateStatus(assessmentId, newStatus)
   }
 }

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -7,14 +7,12 @@ export default class PersonService {
   async findByPrisonNumber(token: string, nomsNumber: string): Promise<FullPerson> {
     const personClient = this.personClientFactory(token)
 
-    const person = await personClient.searchByPrisonNumber(nomsNumber)
-    return person
+    return personClient.searchByPrisonNumber(nomsNumber)
   }
 
   async findByCrn(token: string, crn: string): Promise<FullPerson> {
     const personClient = this.personClientFactory(token)
 
-    const person = await personClient.searchByCrn(crn)
-    return person
+    return personClient.searchByCrn(crn)
   }
 }

--- a/server/services/submittedApplicationService.ts
+++ b/server/services/submittedApplicationService.ts
@@ -17,25 +17,19 @@ export default class SubmittedApplicationService {
   async getAll(token: string, pageNumber: number = 1): Promise<PaginatedResponse<Cas2v2SubmittedApplicationSummary>> {
     const applicationClient = this.submittedApplicationClientFactory(token)
 
-    const applications = await applicationClient.all(pageNumber)
-
-    return applications
+    return applicationClient.all(pageNumber)
   }
 
   async findApplication(token: string, id: string): Promise<SubmittedApplication> {
     const applicationClient = this.submittedApplicationClientFactory(token)
 
-    const application = await applicationClient.find(id)
-
-    return application
+    return applicationClient.find(id)
   }
 
   async getApplicationStatuses(token: string): Promise<Array<ApplicationStatus>> {
     const referenceDataClient = this.referenceDataClientFactory(token)
 
-    const statuses = await referenceDataClient.getApplicationStatuses()
-
-    return statuses
+    return referenceDataClient.getApplicationStatuses()
   }
 
   async addApplicationNote(token: string, applicationId: string, newNote: string): Promise<Cas2v2ApplicationNote> {


### PR DESCRIPTION
# Context

Ticket: https://dsdmoj.atlassian.net/browse/FM-484

Similar to work that's been done on CAS1 and CAS3 lately to reduce the amount of type casting in the service layer
Also returning promises in the client/service layer rather than awaiting and returning the result

