### PR TITLE
Refactored to re-enable type checking

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -71,6 +71,22 @@ jobs:
           script: |
             core.setFailed('Unit tests failed')
 
+  type_checking:
+    name: "Type check"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # V6.0.2
+      - name: Setup Node.js environment
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # V6.3.0
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci --no-audit
+      - name: Run type check
+        run: npm run typecheck
+
   # generic node integration tests using wiremock - feel free to override with local tests if required
   node_integration_tests:
     name: node integration tests

--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -4,7 +4,9 @@ $path: "/assets/images/";
 $moj-page-width: 1170px;
 $govuk-page-width: $moj-page-width;
 
-@import "govuk-frontend/dist/govuk/all";
+@use "govuk-frontend/dist/govuk/index" with (
+  $govuk-global-styles: true
+);
 @import "@ministryofjustice/frontend/moj/all";
 
 @import './components/header-bar';

--- a/assets/scss/components/_header-bar.scss
+++ b/assets/scss/components/_header-bar.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .hmpps-header {
   @include govuk-responsive-padding(3, 'top');
   @include govuk-responsive-padding(3, 'bottom');

--- a/integration_tests/mockApis/submissions.ts
+++ b/integration_tests/mockApis/submissions.ts
@@ -1,7 +1,7 @@
 import type {
-  Cas2SubmittedApplication as SubmittedApplication,
-  Cas2AssessmentStatusUpdate as AssessmentStatusUpdate,
-  Cas2SubmittedApplicationSummary,
+  Cas2v2SubmittedApplication as SubmittedApplication,
+  Cas2v2AssessmentStatusUpdate as AssessmentStatusUpdate,
+  Cas2v2SubmittedApplicationSummary,
 } from '@approved-premises/api'
 import { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
@@ -21,7 +21,7 @@ export default {
       },
     }),
   stubSubmittedApplicationsGet: (args: {
-    applications: Array<Cas2SubmittedApplicationSummary>
+    applications: Array<Cas2v2SubmittedApplicationSummary>
     page: number
   }): SuperAgentRequest =>
     stubFor({

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -18,10 +18,13 @@ export default abstract class Page {
 
   protected constructor(
     private readonly title: string,
-    private readonly name: string,
+    private readonly name?: string,
   ) {
     this.checkOnPage()
-    this.checkNameIsNotInDocumentTitle()
+
+    if (name) {
+      this.checkNameIsNotInDocumentTitle()
+    }
   }
 
   checkOnPage(): void {

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -5,7 +5,11 @@
     "lib": ["es5", "dom", "es2015.promise"],
     "types": ["cypress", "cypress-axe", "express", "express-session"],
     "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "baseUrl": ".",
     "skipLibCheck": true,
+    "experimentalDecorators": true,
     "paths": {
       "@approved-premises/ui": ["../server/@types/ui/index.d.ts"],
       "@approved-premises/api": ["../server/@types/shared/index.d.ts"]

--- a/server/config.ts
+++ b/server/config.ts
@@ -56,7 +56,7 @@ export default {
   redis: {
     enabled: get('REDIS_ENABLED', 'false', requiredInProduction) === 'true',
     host: get('REDIS_HOST', 'localhost', requiredInProduction),
-    port: parseInt(process.env.REDIS_PORT, 10) || 6379,
+    port: parseInt(process.env.REDIS_PORT as string, 10) || 6379,
     password: process.env.REDIS_AUTH_TOKEN,
     tls_enabled: get('REDIS_TLS_ENABLED', 'false'),
   },

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -36,7 +36,7 @@ export type DataAccess = ReturnType<typeof dataAccess>
 
 export {
   HmppsAuthClient,
-  RestClientBuilder,
+  type RestClientBuilder,
   PersonClient,
   ApplicationClient,
   AssessmentClient,

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -3,14 +3,13 @@ import type { FormArtifact, JourneyType, UiTask } from '@approved-premises/ui'
 import { TaskListPageInterface } from '../taskListPage'
 
 export const getTask = <T>(task: T) => {
-  const taskPages = {}
+  const taskPages: Record<string, unknown> = {}
   const slug = Reflect.getMetadata('task:slug', task)
   const name = Reflect.getMetadata('task:name', task)
   const pageClasses = Reflect.getMetadata('task:pages', task)
 
   pageClasses.forEach(<PageType>(page: PageType) => {
-    const pageName = Reflect.getMetadata('page:name', page)
-    // @ts-expect-error Requires refactor to satisfy TS7053
+    const pageName = Reflect.getMetadata('page:name', page) as string
     taskPages[pageName] = page
   })
 

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -1,4 +1,27 @@
-export const getQuestions = (name: string) => {
+export type Question = { question: string; answers?: Record<string, string>; hint?: string }
+type QuestionsNode = { [property: string]: Question | QuestionsNode }
+export type Questions = ReturnType<typeof getQuestions>
+
+export function getQuestion(questions: Questions, ...categories: string[]): Question | undefined {
+  function recurse(node: Question | QuestionsNode, ...keys: string[]): Question | undefined {
+    if (keys.length === 0) {
+      return node as Question
+    }
+
+    const [head, ...tail] = keys
+
+    if (Object.keys(node).includes(head)) {
+      const next = (node as QuestionsNode)[head]
+      return recurse(next, ...tail)
+    }
+
+    return undefined
+  }
+
+  return recurse(questions as QuestionsNode, ...categories)
+}
+
+export function getQuestions(name: string) {
   const yesOrNo = { yes: 'Yes', no: 'No' }
   const yesNoOrIDontKnow = { yes: 'Yes', no: 'No', dontKnow: `I don't know` }
   const riskLevelAnswers = {

--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -273,20 +273,20 @@ describe('checkYourAnswersUtils', () => {
 
         const mockApplicationNoAnswers = applicationFactory.build({
           data: {
-            'confirm-eligibility': {
-              page1: {
-                question1: '',
-                question2: '',
+            'confirm-consent': {
+              'confirm-consent': {
+                hasGivenConsent: '',
+                consentDate: '',
               },
             },
           },
         })
 
-        const mockedQuestions = {
-          'confirm-eligibility': {
-            page1: {
-              question1: { question: 'A question', answers: { yes: 'Yes', no: 'No' } },
-              question2: { question: 'Another question' },
+        const mockedQuestions: Partial<Questions> = {
+          'confirm-consent': {
+            'confirm-consent': {
+              hasGivenConsent: { question: 'A question', answers: { yes: 'Yes', no: 'No' } },
+              consentDate: { question: 'Another question', hint: 'Some hint' },
             },
           },
         }
@@ -296,9 +296,9 @@ describe('checkYourAnswersUtils', () => {
         addPageAnswersToItemsArray({
           items,
           application: mockApplicationNoAnswers,
-          task: 'confirm-eligibility',
-          pageKey: 'page1',
-          questions: mockedQuestions,
+          task: 'confirm-consent',
+          pageKey: 'confirm-consent',
+          questions: mockedQuestions as Questions,
           outputFormat: 'checkYourAnswers',
         })
 
@@ -319,11 +319,10 @@ describe('checkYourAnswersUtils', () => {
           },
         })
 
-        const mockedQuestions = {
+        const mockedQuestions: Partial<Questions> = {
           'confirm-eligibility': {
-            page2: {
-              question3: { question: 'A question', answers: { yes: 'Yes', no: 'No' } },
-              question4: { question: 'Another question' },
+            'confirm-eligibility': {
+              isEligible: { question: 'A question', answers: { yes: 'Yes', no: 'No' } },
             },
           },
         }
@@ -335,7 +334,7 @@ describe('checkYourAnswersUtils', () => {
           application: mockApplicationRemovedQuestion,
           task: 'confirm-eligibility',
           pageKey: 'page1',
-          questions: mockedQuestions,
+          questions: mockedQuestions as Questions,
           outputFormat: 'checkYourAnswers',
         })
 

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -3,7 +3,7 @@ import { SummaryListItem, FormSection, QuestionAndAnswer } from '@approved-premi
 import Apply from '../form-pages/apply/index'
 import CheckYourAnswers from '../form-pages/apply/check-your-answers'
 import paths from '../paths/apply'
-import { getQuestions } from '../form-pages/utils/questions'
+import { getQuestions, getQuestion, Questions } from '../form-pages/utils/questions'
 import { nameOrPlaceholderCopy } from './utils'
 import { formatLines } from './viewUtils'
 import TaskListPage, { TaskListPageInterface } from '../form-pages/taskListPage'
@@ -64,7 +64,7 @@ export const addPageAnswersToItemsArray = (params: {
   application: Application
   task: string
   pageKey: string
-  questions: Record<string, unknown>
+  questions: Questions
   outputFormat: 'checkYourAnswers' | 'document'
 }) => {
   const { items, application, task, pageKey, questions, outputFormat } = params
@@ -73,9 +73,9 @@ export const addPageAnswersToItemsArray = (params: {
   const body = application?.data?.[task]?.[pageKey]
 
   const page = new PageClass(body, application)
+  const response = page.response?.()
 
-  if (hasResponseMethod(page)) {
-    const response = page.response()
+  if (response) {
     Object.keys(response).forEach((question, index) => {
       if (outputFormat === 'checkYourAnswers') {
         items.push(
@@ -94,8 +94,7 @@ export const addPageAnswersToItemsArray = (params: {
           return
         }
 
-        // @ts-expect-error Requires refactor to satisfy TS7053
-        const questionText = questions[task][pageKey]?.[questionKey]?.question
+        const questionText = getQuestion(questions, task, pageKey, questionKey)?.question
 
         if (!questionText) {
           return
@@ -113,7 +112,7 @@ export const addPageAnswersToItemsArray = (params: {
 
 export const getAnswer = (
   application: Application,
-  questions: Record<string, unknown>,
+  questions: Questions,
   task: string,
   pageKey: string,
   questionKey: string,
@@ -122,24 +121,25 @@ export const getAnswer = (
     if (Array.isArray(application.data[task][pageKey][questionKey])) {
       return arrayAnswersAsString(application, questions, task, pageKey, questionKey)
     }
-    // @ts-expect-error Requires refactor to satisfy TS7053
-    return questions[task][pageKey][questionKey].answers[application.data[task][pageKey][questionKey]]
+
+    const question = getQuestion(questions, task, pageKey, questionKey)
+    return question?.answers?.[application.data[task][pageKey][questionKey]]
   }
   return application.data[task][pageKey][questionKey]
 }
 
 export const arrayAnswersAsString = (
   application: Application,
-  questions: Record<string, unknown>,
+  questions: Questions,
   task: string,
   pageKey: string,
   questionKey: string,
 ): string => {
   const answerKeys = application.data[task][pageKey][questionKey]
   const textAnswers: Array<string> = []
+  const question = getQuestion(questions, task, pageKey, questionKey)
   answerKeys.forEach((answerKey: string) => {
-    // @ts-expect-error Requires refactor to satisfy TS7053
-    textAnswers.push(questions[task][pageKey][questionKey].answers[answerKey])
+    textAnswers.push(question.answers[answerKey])
   })
   return textAnswers.join()
 }
@@ -200,21 +200,12 @@ const containsQuestions = (questionKeys: Array<string>): boolean => {
   return true
 }
 
-const hasDefinedAnswers = (
-  questions: Record<string, unknown>,
-  task: string,
-  pageKey: string,
-  questionKey: string,
-): boolean => {
-  // @ts-expect-error Requires refactor to satisfy TS7053
-  return questions[task][pageKey]?.[questionKey]?.answers
+const hasDefinedAnswers = (questions: Questions, task: string, pageKey: string, questionKey: string): boolean => {
+  return getQuestion(questions, task, pageKey, questionKey)?.answers !== undefined
 }
 
 export const hasResponseMethod = (page: TaskListPage): boolean => {
-  if ('response' in page) {
-    return true
-  }
-  return false
+  return 'response' in page
 }
 
 export const getPage = (taskName: string, pageName: string): TaskListPageInterface => {
@@ -279,7 +270,7 @@ export const getApplicantDetails = (application: Application | Cas2v2SubmittedAp
         text: 'Prison number',
       },
       value: {
-        html: nomsNumber,
+        html: nomsNumber ?? '',
       },
     },
     {
@@ -287,7 +278,7 @@ export const getApplicantDetails = (application: Application | Cas2v2SubmittedAp
         text: 'Prison',
       },
       value: {
-        html: prisonName,
+        html: prisonName ?? '',
       },
     },
     {

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -6,26 +6,24 @@ export const escape = (text: string): string => {
   return escapeFilter(text).val
 }
 
-export function convertKeyValuePairToRadioItems<T>(object: T, checkedItem: string): Array<RadioItem> {
-  return Object.keys(object).map(key => {
+export function convertKeyValuePairToRadioItems<T extends object>(object: T, checkedItem: string): Array<RadioItem> {
+  return Object.entries(object).map(([key, value]) => {
     return {
       value: key,
-      // @ts-expect-error Requires refactor to satisfy TS7053
-      text: object[key],
+      text: value,
       checked: checkedItem === key,
     }
   })
 }
 
-export function convertKeyValuePairToCheckboxItems<T>(
+export function convertKeyValuePairToCheckboxItems<T extends object>(
   object: T,
   checkedItems: Array<string> = [],
 ): Array<CheckboxItem> {
-  return Object.keys(object).map(key => {
+  return Object.entries(object).map(([key, value]) => {
     return {
       value: key,
-      // @ts-expect-error Requires refactor to satisfy TS7053
-      text: object[key],
+      text: value,
       checked: checkedItems.includes(key),
     }
   })
@@ -57,7 +55,7 @@ export const summaryListItem = (
   value: string,
   renderAs: keyof TextItem | keyof HtmlItem | 'textBlock' = 'text',
   supressBlank = false,
-): SummaryListItem => {
+): SummaryListItem | undefined => {
   const htmlValue = renderAs === 'textBlock' ? `<span class="govuk-summary-list__textblock">${value}</span>` : value
   return !supressBlank || value
     ? {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,22 @@
 {
-  "extends": "@tsconfig/node22/tsconfig.json",
   "compileOnSave": true,
   "compilerOptions": {
     "target": "es2018",
+    "module": "commonjs",
+    "moduleResolution": "node",
     "outDir": "./dist",
     "sourceMap": true,
     "skipLibCheck": true,
     "noEmit": false,
-    "allowJs": false,
+    "allowJs": true,
+    "checkJs": true,
     "strict": false,
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "isolatedModules": true,
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
     "experimentalDecorators": true,
-    "strictPropertyInitialization": false,
     "typeRoots": ["./server/@types", "./node_modules/@types"],
     "baseUrl": ".",
     "paths": {
@@ -22,8 +24,17 @@
       "@approved-premises/ui": ["server/@types/ui/index.d.ts"]
     }
   },
-  "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist", "cypress.config.ts",
-    "esbuild-configs"
+  "exclude": [
+    "node_modules",
+    "assets/**/*.js",
+    "integration_tests",
+    "dist",
+    "esbuild",
+    "cypress.config.ts",
+    "esbuild-configs",
+    "coverage/**",
+    "e2e-tests/playwright-report/**",
+    "e2e-tests/test_results/**",
   ],
   "include": ["**/*.js", "**/*.ts"]
 }


### PR DESCRIPTION
# Context

Ticket: https://dsdmoj.atlassian.net/browse/FM-485

Tried to remove as many `@ts-expect-error` as I could and bring type checking in line with the other CASs

Strict type checking is still disabled, but there are hundreds of minor fixes required to re-enable - probably best to do minor refactors with each ISR change if possible
