### PR TITLE
Updated sha for hmpps-github-actions

### DIFF
--- a/.github/workflows/deploy_to_env.yml
+++ b/.github/workflows/deploy_to_env.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   helm_lint:
     name: helm lint
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     secrets: inherit
     with:
       environment: ${{ inputs.environment }}
@@ -33,7 +33,7 @@ jobs:
     name: Deploy to environment
     needs:
       - helm_lint
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     secrets: inherit
     with:
       environment: ${{ inputs.environment }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -25,7 +25,7 @@ jobs:
   # main node build workflow
   node_build:
     name: node build
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/node_build.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/node_build.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     secrets: inherit
 
   node_unit_tests:
@@ -98,14 +98,14 @@ jobs:
       matrix:
         environments: ['development','test','preprod','prod']
     name: helm lint
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     secrets: inherit
     with:
       environment: ${{ matrix.environments }}
   build:
     name: Build docker image from hmpps-github-actions
     if: github.ref == 'refs/heads/main'
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     needs:
       - node_integration_tests
       - node_unit_tests
@@ -120,7 +120,7 @@ jobs:
     needs: 
       - build
       - helm_lint
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     secrets: inherit
     with:
       environment: 'development'
@@ -136,7 +136,7 @@ jobs:
     needs:
       - build
     if: github.ref == 'refs/heads/main'
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     secrets: inherit
     with:
       environment: 'test'
@@ -147,7 +147,7 @@ jobs:
       - build
       - deploy_dev
       - node_e2e_tests
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     secrets: inherit
     with:
       environment: 'preprod'
@@ -157,7 +157,7 @@ jobs:
     needs: 
       - build
       - deploy_preprod
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     secrets: inherit
     with:
       environment: 'prod'

--- a/.github/workflows/security_codeql_actions_scan.yml
+++ b/.github/workflows/security_codeql_actions_scan.yml
@@ -12,7 +12,7 @@ jobs:
       actions: read
       security-events: write
     name: Project security CodeQL actions scan
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_codeql_actions.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_codeql_actions.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.github/workflows/security_codeql_scan.yml
+++ b/.github/workflows/security_codeql_scan.yml
@@ -12,7 +12,7 @@ jobs:
       actions: read
       security-events: write
     name: Project security CodeQL scan
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_codeql.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_codeql.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
       languages: 'javascript-typescript'

--- a/.github/workflows/security_npm_dependency.yml
+++ b/.github/workflows/security_npm_dependency.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       actions: read
       security-events: write
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_npm_dependency.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_npm_dependency.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       actions: read
       security-events: write
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_pipeline_scan.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_pipeline_scan.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       actions: read
       security-events: write
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_policy_scan.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # 2.9.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_policy_scan.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit


### PR DESCRIPTION
# Context

I noticed that the `deploy_dev` action has started failing, which is likely related to us using a version of `hmpps-github-actions` that itself didn't use pinned sha versions. All the security actions have also started failing.

There was a large change a couple of days ago to remove all of the old actions from that repo, which affects any previous pinned actions that themselves didn't have pinned actions.

Failing action: https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui/actions/runs/24776836373/job/72499870254

Change to remove actions: https://github.com/ministryofjustice/hmpps-github-actions/commit/809391be5487345d9e000efe8d0192751c013706
