### PR TITLE
Reverted CSS changes from refactor PR

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -4,9 +4,7 @@ $path: "/assets/images/";
 $moj-page-width: 1170px;
 $govuk-page-width: $moj-page-width;
 
-@use "govuk-frontend/dist/govuk/index" with (
-  $govuk-global-styles: true
-);
+@import "govuk-frontend/dist/govuk/all";
 @import "@ministryofjustice/frontend/moj/all";
 
 @import './components/header-bar';

--- a/assets/scss/components/_header-bar.scss
+++ b/assets/scss/components/_header-bar.scss
@@ -1,5 +1,3 @@
-@use "govuk-frontend/dist/govuk" as *;
-
 .hmpps-header {
   @include govuk-responsive-padding(3, 'top');
   @include govuk-responsive-padding(3, 'bottom');


### PR DESCRIPTION
# Context

Reverted the CSS changes from my [most recent refactor PR](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui/pull/534), as they were causing visual issues while I was testing my changes

The changes were made in the first place to try to get rid of some of the errors I see when running `npm run build`:
```
▲ [WARNING] sass warning: Importing using 'govuk/all' is deprecated. Update your import statement to import 'govuk/index'. To silence this warning, update $govuk-suppressed-warnings with key: "import-using-all" [plugin sass-plugin]
```

# Changes in this PR

## Screenshots of UI changes

### Before
<img width="1358" height="900" alt="image" src="https://github.com/user-attachments/assets/c41381b9-814e-4e5a-af02-4b0b59b3ad5c" />

### After
<img width="1606" height="888" alt="image" src="https://github.com/user-attachments/assets/0b288405-aee9-4ebd-ab3e-123fe08cc8e6" />

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
