### PR TITLE
Fixing tsc --strict errors - part 2

### DIFF
--- a/e2e-tests/steps/reports.ts
+++ b/e2e-tests/steps/reports.ts
@@ -1,4 +1,4 @@
-import { Page, expect } from '@playwright/test'
+import { expect, Page } from '@playwright/test'
 import Excel, { CellValue } from 'exceljs'
 
 const reportTypeMetaData = {
@@ -39,8 +39,7 @@ export const downloadReport = async (reportType: ReportType, page: Page) => {
   const downloadPromise = page.waitForEvent('download', { timeout: 10000 })
   await page.getByRole('button', { name: reportTypeMetaData[reportType].callToAction }).click()
   const download = await downloadPromise
-  const path = await download.path()
-  return path
+  return download.path()
 }
 
 export const confirmColumnNames = async (reportType: ReportType, path: string) => {
@@ -48,9 +47,10 @@ export const confirmColumnNames = async (reportType: ReportType, path: string) =
 
   await workbook.xlsx.readFile(path).then(() => {
     const sh = workbook.getWorksheet('Sheet0')
+    expect(sh).toBeDefined()
 
     const headerCells: CellValue[] = []
-    sh.getRow(1).eachCell(cell => headerCells.push(cell.value))
+    sh!.getRow(1).eachCell(cell => headerCells.push(cell.value))
 
     reportTypeMetaData[reportType].columnNames.forEach(columnName => {
       expect(headerCells.includes(columnName)).toBe(true)

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -94,7 +94,7 @@ export type RiskTierLevel = `${TierLetter}${TierNumber}`
 // A utility type that allows us to define an object with a date attribute split into
 // date, month, year (and optionally, time) attributes. Designed for use with the GOV.UK
 // date input
-export type ObjectWithDateParts<K extends string | number> = { [P in `${K}-${'year' | 'month' | 'day'}`]: string } & {
+export type ObjectWithDateParts<K extends string | number> = { [P in `${K}-${'year' | 'month' | 'day'}`]?: string } & {
   [P in `${K}-time`]?: string
 } & {
   [P in K]?: string

--- a/server/form-pages/apply/about-the-person/personal-information/gender.test.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/gender.test.ts
@@ -20,7 +20,7 @@ describe('Gender', () => {
 
   describe('errors', () => {
     it('returns an error if gender is not set', () => {
-      const page = new Gender({ gender: null }, application)
+      const page = new Gender({ gender: undefined }, application)
 
       expect(page.errors()).toEqual({
         gender:

--- a/server/form-pages/apply/about-the-person/personal-information/gender.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/gender.ts
@@ -7,7 +7,7 @@ import { getQuestions } from '../../../utils/questions'
 
 export type GenderBody = {
   gender: YesOrNoOrPreferNotToSay
-  genderIdentity: string
+  genderIdentity?: string
 }
 
 @Page({

--- a/server/form-pages/apply/about-the-person/personal-information/pregnancyInformation.test.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/pregnancyInformation.test.ts
@@ -27,7 +27,7 @@ describe('PregnancyInformation', () => {
 
   describe('errors', () => {
     it('returns an error if isPregnant is not set', () => {
-      const page = new PregnancyInformation({ isPregnant: null }, application)
+      const page = new PregnancyInformation({ isPregnant: undefined }, application)
 
       expect(page.errors()).toEqual({
         isPregnant: `Choose either Yes, No or I don't know`,
@@ -36,7 +36,7 @@ describe('PregnancyInformation', () => {
 
     describe('when isPregnant is yes', () => {
       it('returns an error if dueDate is not set', () => {
-        const page = new PregnancyInformation({ ...body, 'dueDate-year': null }, application)
+        const page = new PregnancyInformation({ ...body, 'dueDate-year': undefined }, application)
 
         expect(page.errors()).toEqual({
           dueDate: 'Enter the due date',

--- a/server/form-pages/apply/about-the-person/personal-information/pregnancyInformation.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/pregnancyInformation.ts
@@ -1,5 +1,5 @@
 import { Cas2v2Application as Application } from '@approved-premises/api'
-import { TaskListErrors, YesNoOrDontKnow } from '@approved-premises/ui'
+import { ObjectWithDateParts, TaskListErrors, YesNoOrDontKnow } from '@approved-premises/ui'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../../utils/dateUtils'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import TaskListPage from '../../../taskListPage'
@@ -8,10 +8,10 @@ import { getQuestions } from '../../../utils/questions'
 
 export type PregnancyInformationBody = {
   isPregnant: YesNoOrDontKnow
-  dueDate: string
-  'dueDate-month': string
-  'dueDate-year': string
-  'dueDate-day': string
+  dueDate?: string
+  'dueDate-month'?: string
+  'dueDate-year'?: string
+  'dueDate-day'?: string
 }
 
 @Page({
@@ -51,7 +51,10 @@ export default class PregnancyInformation implements TaskListPage {
       errors.isPregnant = `Choose either Yes, No or I don't know`
     }
 
-    if (this.body.isPregnant === 'yes' && !dateAndTimeInputsAreValidDates(this.body, 'dueDate')) {
+    if (
+      this.body.isPregnant === 'yes' &&
+      !dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'dueDate'>, 'dueDate')
+    ) {
       errors.dueDate = 'Enter the due date'
     }
 

--- a/server/form-pages/apply/about-the-person/personal-information/workingMobilePhone.test.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/workingMobilePhone.test.ts
@@ -25,7 +25,7 @@ describe('WorkingMobilePhone', () => {
 
   describe('errors', () => {
     it('returns an error if hasWorkingMobilePhone is not set', () => {
-      const page = new WorkingMobilePhone({ hasWorkingMobilePhone: null }, application)
+      const page = new WorkingMobilePhone({ hasWorkingMobilePhone: undefined }, application)
 
       expect(page.errors()).toEqual({
         hasWorkingMobilePhone: `Choose either Yes, No or I don't know`,
@@ -34,7 +34,7 @@ describe('WorkingMobilePhone', () => {
 
     describe('when hasWorkingMobilePhone is yes', () => {
       it('returns an error if isSmartPhone is not set', () => {
-        const page = new WorkingMobilePhone({ ...body, isSmartPhone: null }, application)
+        const page = new WorkingMobilePhone({ ...body, isSmartPhone: undefined }, application)
 
         expect(page.errors()).toEqual({
           isSmartPhone: 'Choose either Yes or No',

--- a/server/form-pages/apply/about-the-person/personal-information/workingMobilePhone.ts
+++ b/server/form-pages/apply/about-the-person/personal-information/workingMobilePhone.ts
@@ -7,8 +7,8 @@ import { getQuestions } from '../../../utils/questions'
 
 export type WorkingMobilePhoneBody = {
   hasWorkingMobilePhone: YesNoOrDontKnow
-  mobilePhoneNumber: string
-  isSmartPhone: YesOrNo
+  mobilePhoneNumber?: string
+  isSmartPhone?: YesOrNo
 }
 
 @Page({

--- a/server/form-pages/apply/area-and-funding/area-information/exclusionZones.test.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/exclusionZones.test.ts
@@ -24,7 +24,7 @@ describe('ExclusionZones', () => {
 
   describe('errors', () => {
     it('returns an error if hasExclusionZones is not set', () => {
-      const page = new ExclusionZones({ ...body, hasExclusionZones: null }, application)
+      const page = new ExclusionZones({ ...body, hasExclusionZones: undefined }, application)
 
       expect(page.errors()).toEqual({
         hasExclusionZones: 'Select if they have any exclusion zones',
@@ -33,7 +33,7 @@ describe('ExclusionZones', () => {
 
     describe('when hasExclusionZones is set to yes', () => {
       it('returns an error if exclusionZonesDetail is not set', () => {
-        const page = new ExclusionZones({ hasExclusionZones: 'yes', exclusionZonesDetail: null }, application)
+        const page = new ExclusionZones({ hasExclusionZones: 'yes', exclusionZonesDetail: undefined }, application)
 
         expect(page.errors()).toEqual({
           exclusionZonesDetail: 'Select if there are any exclusion zones or unsuitable areas',

--- a/server/form-pages/apply/area-and-funding/area-information/exclusionZones.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/exclusionZones.ts
@@ -7,7 +7,7 @@ import { getQuestions } from '../../../utils/questions'
 
 export type ExclusionZonesBody = {
   hasExclusionZones: YesOrNo
-  exclusionZonesDetail: string
+  exclusionZonesDetail?: string
 }
 
 @Page({

--- a/server/form-pages/apply/area-and-funding/area-information/familyAccommodation.test.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/familyAccommodation.test.ts
@@ -23,7 +23,7 @@ describe('FamilyAccommodation', () => {
 
   describe('errors', () => {
     it('returns an error if familyProperty is not set', () => {
-      const page = new FamilyAccommodation({ familyProperty: null }, application)
+      const page = new FamilyAccommodation({ familyProperty: undefined }, application)
 
       expect(page.errors()).toEqual({
         familyProperty: 'Select yes if they want to apply to live with their children in a family property',

--- a/server/form-pages/apply/area-and-funding/area-information/firstPreferredArea.test.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/firstPreferredArea.test.ts
@@ -23,7 +23,7 @@ describe('FirstPreferredArea', () => {
 
   describe('errors', () => {
     it('returns an error if preferredArea is not set', () => {
-      const page = new FirstPreferredArea({ ...body, preferredArea: null }, application)
+      const page = new FirstPreferredArea({ ...body, preferredArea: undefined }, application)
 
       expect(page.errors()).toEqual({
         preferredArea: 'Provide a town, city or region for the first preferred area',
@@ -31,7 +31,7 @@ describe('FirstPreferredArea', () => {
     })
 
     it('returns an error if preferenceReason is not set', () => {
-      const page = new FirstPreferredArea({ ...body, preferenceReason: null }, application)
+      const page = new FirstPreferredArea({ ...body, preferenceReason: undefined }, application)
 
       expect(page.errors()).toEqual({
         preferenceReason: "Provide the reason for the applicant's first preferred area",

--- a/server/form-pages/apply/area-and-funding/area-information/gangAffiliations.test.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/gangAffiliations.test.ts
@@ -14,7 +14,7 @@ describe('GangAffiliations', () => {
   describe('errors', () => {
     describe('when top level fields are unanswered', () => {
       it('returns an error for hasGangAffiliations', () => {
-        const page = new GangAffiliations({ hasGangAffiliations: null }, application)
+        const page = new GangAffiliations({ hasGangAffiliations: undefined }, application)
 
         expect(page.errors()).toHaveProperty(
           'hasGangAffiliations',
@@ -23,7 +23,7 @@ describe('GangAffiliations', () => {
       })
 
       it('returns an error for rivalGangsOrCountyLines', () => {
-        const page = new GangAffiliations({ rivalGangsOrCountyLines: null }, application)
+        const page = new GangAffiliations({ rivalGangsOrCountyLines: undefined }, application)
 
         expect(page.errors()).toHaveProperty(
           'rivalGangsOrCountyLines',
@@ -34,7 +34,7 @@ describe('GangAffiliations', () => {
 
     describe('when hasGangAffiliations is set to yes', () => {
       it('returns an error if gangDetails is not set', () => {
-        const page = new GangAffiliations({ hasGangAffiliations: 'yes', gangDetails: null }, application)
+        const page = new GangAffiliations({ hasGangAffiliations: 'yes', gangDetails: undefined }, application)
 
         expect(page.errors()).toHaveProperty('gangDetails', 'Enter details of the gang')
       })
@@ -42,7 +42,10 @@ describe('GangAffiliations', () => {
 
     describe('when hasGangAffiliations is set to not known', () => {
       it('returns an error if gangNotKnownDetails is not set', () => {
-        const page = new GangAffiliations({ hasGangAffiliations: 'dontKnow', gangNotKnownDetails: null }, application)
+        const page = new GangAffiliations(
+          { hasGangAffiliations: 'dontKnow', gangNotKnownDetails: undefined },
+          application,
+        )
 
         expect(page.errors()).toHaveProperty('gangNotKnownDetails', 'Enter why it is not known')
       })
@@ -51,7 +54,7 @@ describe('GangAffiliations', () => {
     describe('when rivalGangsOrCountyLines is set to not known', () => {
       it('returns an error if rivalGangNotKnownDetail is not set', () => {
         const page = new GangAffiliations(
-          { rivalGangsOrCountyLines: 'dontKnow', rivalGangNotKnownDetail: null },
+          { rivalGangsOrCountyLines: 'dontKnow', rivalGangNotKnownDetail: undefined },
           application,
         )
 

--- a/server/form-pages/apply/area-and-funding/area-information/gangAffiliations.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/gangAffiliations.ts
@@ -7,11 +7,11 @@ import { getQuestions } from '../../../utils/questions'
 
 export type GangAffiliationsBody = {
   hasGangAffiliations: YesNoOrDontKnow
-  gangDetails: string
-  gangNotKnownDetails: string
+  gangDetails?: string
+  gangNotKnownDetails?: string
   rivalGangsOrCountyLines: YesNoOrDontKnow
-  rivalGangsOrCountyLinesDetail: string
-  rivalGangNotKnownDetail: string
+  rivalGangsOrCountyLinesDetail?: string
+  rivalGangNotKnownDetail?: string
 }
 
 @Page({

--- a/server/form-pages/apply/area-and-funding/area-information/secondPreferredArea.test.ts
+++ b/server/form-pages/apply/area-and-funding/area-information/secondPreferredArea.test.ts
@@ -23,7 +23,7 @@ describe('SecondPreferredArea', () => {
 
   describe('errors', () => {
     it('returns an error if preferredArea is not set', () => {
-      const page = new SecondPreferredArea({ ...body, preferredArea: null }, application)
+      const page = new SecondPreferredArea({ ...body, preferredArea: undefined }, application)
 
       expect(page.errors()).toEqual({
         preferredArea: 'Provide a town, city or region for the second preferred area',
@@ -31,7 +31,7 @@ describe('SecondPreferredArea', () => {
     })
 
     it('returns an error if preferenceReason is not set', () => {
-      const page = new SecondPreferredArea({ ...body, preferenceReason: null }, application)
+      const page = new SecondPreferredArea({ ...body, preferenceReason: undefined }, application)
 
       expect(page.errors()).toEqual({
         preferenceReason: "Provide the reason for the applicant's second preferred area",

--- a/server/form-pages/apply/area-and-funding/funding-information/alternativeApplicantID.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/alternativeApplicantID.ts
@@ -13,7 +13,7 @@ const alternativeIDOptions = applicationQuestions.alternativeIDDocuments.answers
 
 export type AlternativeIdentificationBody = {
   alternativeIDDocuments: Array<keyof typeof alternativeIDOptions>
-  other: string
+  other?: string
 }
 
 @Page({
@@ -39,6 +39,7 @@ export default class AlternativeIdentification implements TaskListPage {
     body: Partial<AlternativeIdentificationBody>,
     private readonly application: Application,
   ) {
+    this.body = body as AlternativeIdentificationBody
     this.questions = getQuestions(this.personName)['funding-information']['alternative-applicant-id']
     this.title = this.questions.alternativeIDDocuments.question
   }

--- a/server/form-pages/apply/area-and-funding/funding-information/applicantID.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/applicantID.ts
@@ -36,6 +36,7 @@ export default class ApplicantID implements TaskListPage {
     body: Partial<ApplicantIDBody>,
     private readonly application: Application,
   ) {
+    this.body = body as ApplicantIDBody
     this.questions = getQuestions(this.personName)['funding-information']['applicant-id'].idDocuments
     this.title = this.questions.question
   }

--- a/server/form-pages/apply/area-and-funding/funding-information/fundingCas2Accommodation.test.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/fundingCas2Accommodation.test.ts
@@ -59,7 +59,7 @@ describe('FundingCas2Accommodation', () => {
             hasNationalInsuranceNumber: 'yes',
             nationalInsuranceNumber: 'SF123456X',
             receivingBenefits: 'yes',
-            receivedBenefitSanctions: null,
+            receivedBenefitSanctions: undefined,
           },
           application,
         )

--- a/server/form-pages/apply/area-and-funding/funding-information/fundingCas2Accommodation.ts
+++ b/server/form-pages/apply/area-and-funding/funding-information/fundingCas2Accommodation.ts
@@ -13,11 +13,11 @@ const hasNationalInsuranceOptions =
 
 export type FundingCas2AccommodationBody = {
   fundingSource: FundingSources
-  fundingSourceDetail: string
+  fundingSourceDetail?: string
   hasNationalInsuranceNumber: YesNoOrDontKnow
-  nationalInsuranceNumber: string
+  nationalInsuranceNumber?: string
   receivingBenefits: YesOrNo
-  receivedBenefitSanctions: YesOrNo
+  receivedBenefitSanctions?: YesOrNo
 }
 
 @Page({
@@ -39,8 +39,6 @@ export default class FundingCas2Accommodation implements TaskListPage {
   title = 'Funding CAS2 for bail accommodation'
 
   questions
-
-  options: Record<string, string>
 
   body: FundingCas2AccommodationBody
 

--- a/server/form-pages/apply/bail-information/bail-conditions/nonStandardBailConditions.ts
+++ b/server/form-pages/apply/bail-information/bail-conditions/nonStandardBailConditions.ts
@@ -8,7 +8,7 @@ import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
 
 export type NonStandardBailConditionsBody = {
   nonStandardBailConditions: YesNoOrDontKnow
-  nonStandardBailConditionsDetail: string
+  nonStandardBailConditionsDetail?: string
 }
 
 @Page({

--- a/server/form-pages/apply/bail-information/bail-hearing-information/bailHearingInformation.test.ts
+++ b/server/form-pages/apply/bail-information/bail-hearing-information/bailHearingInformation.test.ts
@@ -32,13 +32,13 @@ describe('BailHearingInformation', () => {
     })
 
     describe('when fields are blank', () => {
-      const body: BailHearingInformationBody = {
+      const body: Partial<BailHearingInformationBody> = {
         isBailHearingDateKnown: 'no',
-        'bailHearingDate-month': null,
-        'bailHearingDate-year': null,
-        'bailHearingDate-day': null,
-        courtName: null,
-        bailHearingMedium: null,
+        'bailHearingDate-month': undefined,
+        'bailHearingDate-year': undefined,
+        'bailHearingDate-day': undefined,
+        courtName: undefined,
+        bailHearingMedium: undefined,
       }
 
       it('returns empty strings', () => {

--- a/server/form-pages/apply/bail-information/bail-hearing-information/bailHearingInformation.ts
+++ b/server/form-pages/apply/bail-information/bail-hearing-information/bailHearingInformation.ts
@@ -1,4 +1,4 @@
-import type { TaskListErrors, ObjectWithDateParts, YesOrNo } from '@approved-premises/ui'
+import type { ObjectWithDateParts, TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
 import { Page } from '../../../utils/decorators'
@@ -100,8 +100,6 @@ export default class BailHearingInformation implements TaskListPage {
   }
 
   items() {
-    const items = convertKeyValuePairToRadioItems(hearingMediumOptions, this.body.bailHearingMedium)
-
-    return items
+    return convertKeyValuePairToRadioItems(hearingMediumOptions, this.body.bailHearingMedium)
   }
 }

--- a/server/form-pages/apply/before-you-start/referrer-details/confirmDetails.ts
+++ b/server/form-pages/apply/before-you-start/referrer-details/confirmDetails.ts
@@ -31,7 +31,8 @@ export default class ConfirmReferrerDetails implements TaskListPage {
     body: Partial<ConfirmReferrerDetailsBody>,
     private readonly application: Application,
   ) {
-    this.referrerDetails = { name: application.createdBy.name, email: application.createdBy.email }
+    this.body = body as ConfirmReferrerDetailsBody
+    this.referrerDetails = { name: application.createdBy.name, email: application.createdBy.email ?? '' }
 
     const applicationQuestions = getQuestions(this.personName)
     this.questions = applicationQuestions['referrer-details']['confirm-details']

--- a/server/form-pages/apply/health-needs/health-needs/brainInjury.test.ts
+++ b/server/form-pages/apply/health-needs/health-needs/brainInjury.test.ts
@@ -23,7 +23,7 @@ describe('BrainInjury', () => {
 
   describe('errors', () => {
     it('returns an error if no answer is provided', () => {
-      const page = new BrainInjury({ hasBrainInjury: null }, application)
+      const page = new BrainInjury({ hasBrainInjury: undefined }, application)
 
       expect(page.errors()).toHaveProperty('hasBrainInjury', 'Select yes if they have any brain injury')
     })


### PR DESCRIPTION
# Context

More progress towards enabling strict type checking with `tsc`

> E2E tests have been run locally and are passing

# Changes in this PR

### Before

```sh
$ tsc --strict
...
Found 303 errors in 105 files.
```

### After

```sh
$ tsc --strict
...
Found 258 errors in 82 files.
```

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
