### PR TITLE
Chore: Use CAS1 Slack Failure Notification action v1

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Send Slack notification
         if: failure()
-        uses: ministryofjustice/hmpps-community-accommodation-tier-2-ui/.github/actions/slack_failure_notification@77cc6ec1dd5ed994309df8960421cbd3ba1ad5aa # main 2026-04-02 # main 2026-04-02
+        uses: ministryofjustice/hmpps-approved-premises-ui/.github/actions/slack_failure_notification@d03ccce7b908369b59e77cb4ce13468dbe6e278a # v1
         with:
           title: "CAS2 Bail E2E Tests"
           channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID }}

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   e2e_test:
-    name: Run the e2e tests
+    name: "CAS2 Bail E2E 🧪 Tests"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # V4.3.1
@@ -78,5 +78,6 @@ jobs:
         uses: ministryofjustice/hmpps-approved-premises-ui/.github/actions/slack_failure_notification@d03ccce7b908369b59e77cb4ce13468dbe6e278a # v1
         with:
           title: "CAS2 Bail E2E Tests"
+          job: "e2e_test"
           channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID }}
           slack_bot_token: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}


### PR DESCRIPTION
This PR points the Slack Failure Notification action to the shared action from the CAS1 repository. The action is versioned on the CAS1 repository, so any update will be picked up by Renovate when a new tag is created on the CAS1 repo.