### PR TITLE
Use nonprod severity for nonprod environments

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -25,4 +25,4 @@ generic-service:
      AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
 
 generic-prometheus-alerts:
-  alertSeverity: hmpps-approved-premises
+  alertSeverity: hmpps-approved-premises-nonprod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -25,4 +25,4 @@ generic-service:
      AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
 
 generic-prometheus-alerts:
-  alertSeverity: hmpps-approved-premises
+  alertSeverity: hmpps-approved-premises-nonprod

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -23,4 +23,4 @@ generic-service:
     AUDIT_SQS_QUEUE_NAME: ""
 
 generic-prometheus-alerts:
-  alertSeverity: hmpps-approved-premises
+  alertSeverity: hmpps-approved-premises-nonprod


### PR DESCRIPTION
This will ensure that non prod prometheus alerts will be sent to the non prod slack channel