### PR TITLE
Remove `deploy to test` step from main pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -131,16 +131,6 @@ jobs:
     needs: [deploy_dev]
     uses: ./.github/workflows/e2e_tests.yml
     secrets: inherit
-  deploy_test:
-    name: Deploy to the test environment
-    needs:
-      - build
-    if: github.ref == 'refs/heads/main'
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.2
-    secrets: inherit
-    with:
-      environment: 'test'
-      app_version: '${{ needs.build.outputs.app_version }}'
   deploy_preprod:
     name: Deploy to pre-production environment
     needs: 


### PR DESCRIPTION
There is a separate ‘deploy to env’ workflow to do this.

Removing it from the main pipeline ensures the pipeline appears as complete once deployed to prod. It also allows us to re-run failing E2Es without being forced to deploy to test first
