### PR TITLE
Populate cohort on application update

### DIFF
--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -3,9 +3,28 @@ import applicationDataJson from '../../../integration_tests/fixtures/application
 import { getApplicationSubmissionData, getApplicationUpdateData } from './getApplicationData'
 
 describe('getApplicationUpdateData', () => {
-  it('returns the application data', () => {
-    const mockApplication = applicationFactory.build()
+  it('returns the application data for the prison bail cohort', () => {
+    const mockApplication = applicationFactory.build({ applicationOrigin: 'prisonBail' })
     expect(getApplicationUpdateData(mockApplication)).toEqual({
+      type: 'CAS2V2',
+      data: mockApplication.data,
+      cohort: 'prisonBail',
+    })
+  })
+
+  it('returns the application data for the court bail cohort', () => {
+    const mockApplication = applicationFactory.build({ applicationOrigin: 'courtBail' })
+    expect(getApplicationUpdateData(mockApplication)).toEqual({
+      type: 'CAS2V2',
+      data: mockApplication.data,
+      cohort: 'courtBail',
+    })
+  })
+
+  it('returns the application data for an unimplemented cohort', () => {
+    const mockApplication = applicationFactory.build({ applicationOrigin: 'other' })
+    const result = getApplicationUpdateData(mockApplication)
+    expect(result).toEqual({
       type: 'CAS2V2',
       data: mockApplication.data,
     })

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -1,4 +1,10 @@
-import { Cas2v2Application as Application, SubmitCas2v2Application, UpdateApplication } from '@approved-premises/api'
+import {
+  ApplicationOrigin,
+  Cas2CohortDto,
+  Cas2v2Application as Application,
+  SubmitCas2v2Application,
+  UpdateCas2v2Application,
+} from '@approved-premises/api'
 
 import {
   preferredAreasFromAppData,
@@ -6,11 +12,30 @@ import {
   bailHearingDateFromAppData,
 } from './managementInfoFromAppData'
 
-export const getApplicationUpdateData = (application: Application): UpdateApplication => {
-  return {
+export const getApplicationUpdateData = (application: Application): UpdateCas2v2Application => {
+  const updateApplication: UpdateCas2v2Application = {
     type: 'CAS2V2',
     data: application.data,
   }
+
+  // TODO: remove/refactor once we're choosing the cohort as part of the application flow
+  if (!application.cohort) {
+    updateApplication.cohort = getBailCohort(application.applicationOrigin)
+  }
+
+  return updateApplication
+}
+
+function getBailCohort(applicationOrigin: ApplicationOrigin): Cas2CohortDto | undefined {
+  if (applicationOrigin === 'courtBail') {
+    return 'courtBail'
+  }
+
+  if (applicationOrigin === 'prisonBail') {
+    return 'prisonBail'
+  }
+
+  return undefined
 }
 
 export const getApplicationSubmissionData = (application: Application): SubmitCas2v2Application => {


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/FM-602

Adding the cohort on application update if it isn't currently set.

Setting to either `prisonBail` or `courtBail` depending on the `applicationOrigin`, though this can be expanded/refactored once we add in the new screens to select the origin/cohort as part of the new flow.
