### PR TITLE
Include cohort with every application update

### DIFF
--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -3,8 +3,17 @@ import applicationDataJson from '../../../integration_tests/fixtures/application
 import { getApplicationSubmissionData, getApplicationUpdateData } from './getApplicationData'
 
 describe('getApplicationUpdateData', () => {
+  it('uses the existing cohort when already set in the application', () => {
+    const mockApplication = applicationFactory.build({ cohort: 'courtBail' })
+    expect(getApplicationUpdateData(mockApplication)).toEqual({
+      type: 'CAS2V2',
+      data: mockApplication.data,
+      cohort: mockApplication.cohort,
+    })
+  })
+
   it('returns the application data for the prison bail cohort', () => {
-    const mockApplication = applicationFactory.build({ applicationOrigin: 'prisonBail' })
+    const mockApplication = applicationFactory.build({ applicationOrigin: 'prisonBail', cohort: undefined })
     expect(getApplicationUpdateData(mockApplication)).toEqual({
       type: 'CAS2V2',
       data: mockApplication.data,
@@ -13,7 +22,7 @@ describe('getApplicationUpdateData', () => {
   })
 
   it('returns the application data for the court bail cohort', () => {
-    const mockApplication = applicationFactory.build({ applicationOrigin: 'courtBail' })
+    const mockApplication = applicationFactory.build({ applicationOrigin: 'courtBail', cohort: undefined })
     expect(getApplicationUpdateData(mockApplication)).toEqual({
       type: 'CAS2V2',
       data: mockApplication.data,
@@ -22,11 +31,12 @@ describe('getApplicationUpdateData', () => {
   })
 
   it('returns the application data for an unimplemented cohort', () => {
-    const mockApplication = applicationFactory.build({ applicationOrigin: 'other' })
+    const mockApplication = applicationFactory.build({ applicationOrigin: 'other', cohort: undefined })
     const result = getApplicationUpdateData(mockApplication)
     expect(result).toEqual({
       type: 'CAS2V2',
       data: mockApplication.data,
+      cohort: undefined,
     })
   })
 })

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -13,17 +13,12 @@ import {
 } from './managementInfoFromAppData'
 
 export const getApplicationUpdateData = (application: Application): UpdateCas2v2Application => {
-  const updateApplication: UpdateCas2v2Application = {
+  return {
     type: 'CAS2V2',
     data: application.data,
+    // TODO: refactor once we're choosing the cohort as part of the application flow
+    cohort: application.cohort ?? getBailCohort(application.applicationOrigin),
   }
-
-  // TODO: remove/refactor once we're choosing the cohort as part of the application flow
-  if (!application.cohort) {
-    updateApplication.cohort = getBailCohort(application.applicationOrigin)
-  }
-
-  return updateApplication
 }
 
 function getBailCohort(applicationOrigin: ApplicationOrigin): Cas2CohortDto | undefined {


### PR DESCRIPTION
# Context

Fixed an issue left over from [FM-602](https://dsdmoj.atlassian.net/browse/FM-602) where I was only including the `cohort` if it wasn't already set on an application


[FM-602]: https://dsdmoj.atlassian.net/browse/FM-602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ