### PR TITLE
FM-702 Licence page

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -119,6 +119,33 @@ export default {
       },
     }),
 
+  stubApplicationGetFromLastUpdate: async (args: { application: Application }) => {
+    const {
+      body: { requests },
+    } = await getMatchingRequests({
+      method: 'PUT',
+      url: paths.applications.show({ id: args.application.id }),
+    })
+    const lastPostData = requests.pop()?.body
+    const jsonBody = {
+      ...args.application,
+      ...JSON.parse(lastPostData),
+    }
+    return stubFor({
+      request: {
+        method: 'GET',
+        url: paths.applications.show({ id: args.application.id }),
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody,
+      },
+    })
+  },
+
   verifyApplicationUpdate: async (applicationId: string) =>
     (
       await getMatchingRequests({

--- a/integration_tests/pages/apply/before_you_apply/cohort-selection/cohortSelection.ts
+++ b/integration_tests/pages/apply/before_you_apply/cohort-selection/cohortSelection.ts
@@ -4,7 +4,7 @@ import ApplyPage from '../../applyPage'
 import { cohortSelectionAnswers } from '../../../../../server/utils/applications/cohortLabels'
 
 export default class CohortSelectionPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(readonly application: Application) {
     super(
       `Why does ${(application.person as FullPerson).name} need CAS2 accommodation?`,
       application,
@@ -29,5 +29,13 @@ export default class CohortSelectionPage extends ApplyPage {
       cy.contains(question)
     })
     cy.contains('Provide details (optional)')
+  }
+
+  selectCohort(cohort: string) {
+    CohortSelectionPage.visit(this.application)
+    this.checkRadioByNameAndValue('cohort', cohort)
+    this.clickSubmit('Confirm and continue')
+    cy.task('stubApplicationGetFromLastUpdate', { application: this.application })
+    cy.reload()
   }
 }

--- a/integration_tests/pages/apply/before_you_apply/cohort-selection/licenceDates.ts
+++ b/integration_tests/pages/apply/before_you_apply/cohort-selection/licenceDates.ts
@@ -1,0 +1,47 @@
+import { Cas2CohortDto, Cas2v2Application, Cas2v2Application as Application, FullPerson } from '@approved-premises/api'
+import { faker } from '@faker-js/faker'
+import ApplyPage from '../../applyPage'
+import { DateFormats } from '../../../../../server/utils/dateUtils'
+
+export default class LicenceDatesPage extends ApplyPage {
+  constructor(application: Application) {
+    super(`${(application.person as FullPerson).name}'s licence`, application, 'cohort-selection', 'licence-dates')
+  }
+
+  licenceStartDate = faker.date.soon({ days: 200 })
+
+  licenceEndDate = faker.date.soon({ refDate: this.licenceStartDate, days: 200 })
+
+  completeForm(cohort: Cas2CohortDto): void {
+    if (cohort !== 'rarr')
+      this.completeDateInputs('licenceStartDate', DateFormats.dateObjToIsoDate(this.licenceStartDate))
+    this.completeDateInputs('licenceEndDate', DateFormats.dateObjToIsoDate(this.licenceEndDate))
+    if (cohort === 'atcr') {
+      this.checkRadioByNameAndValue('hasHdcExpiryDate', 'yes')
+      this.completeDateInputs('hdcExpiryDate', DateFormats.dateObjToIsoDate(this.licenceEndDate))
+    }
+  }
+
+  checkDate(body, key: string, date: Date) {
+    expect(body[`${key}-day`]).to.equal(date.getDate().toString())
+    expect(body[`${key}-month`]).to.equal((date.getMonth() + 1).toString())
+    expect(body[`${key}-year`]).to.equal(date.getFullYear().toString())
+  }
+
+  shouldSeeErrrors = (cohort: Cas2CohortDto) => {
+    if (cohort !== 'rarr') this.shouldShowErrorSummary('Licence start date must be entered')
+    this.shouldShowErrorSummary('Licence end date must be entered')
+    if (cohort === 'atcr') this.shouldShowErrorSummary('Select yes if they have a HDC expiry date')
+    else this.shouldNotShowErrorSummary('Select yes if they have a HDC expiry date')
+  }
+
+  verifyUpdate(application: Cas2v2Application) {
+    cy.task('verifyApplicationUpdate', application.id).then(updates => {
+      const lastUpdate = updates[(updates as Array<unknown>).length - 1]
+
+      const licenceDates = JSON.parse(lastUpdate.body).data['cohort-selection']['licence-dates']
+      if (application.cohort !== 'rarr') this.checkDate(licenceDates, 'licenceStartDate', this.licenceStartDate)
+      this.checkDate(licenceDates, 'licenceEndDate', this.licenceEndDate)
+    })
+  }
+}

--- a/integration_tests/pages/apply/before_you_apply/cohort-selection/licenceDatesNeededPage.ts
+++ b/integration_tests/pages/apply/before_you_apply/cohort-selection/licenceDatesNeededPage.ts
@@ -1,0 +1,18 @@
+import { Cas2v2Application as Application, FullPerson } from '@approved-premises/api'
+import ApplyPage from '../../applyPage'
+
+export default class LicenceDatesNeededPage extends ApplyPage {
+  constructor(application: Application) {
+    super(
+      `Is ${(application.person as FullPerson).name} on licence for a different offence?`,
+      application,
+      'cohort-selection',
+      'licence-dates-needed',
+    )
+  }
+
+  answerYes(): void {
+    this.checkRadioByNameAndValue('licenceDatesNeeded', 'yes')
+    this.clickSubmit('Continue')
+  }
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -209,4 +209,8 @@ export default abstract class Page {
   shouldShowErrorSummary(text: string): void {
     cy.get('.govuk-error-summary').should('contain', text)
   }
+
+  shouldNotShowErrorSummary(text: string): void {
+    cy.get('.govuk-error-summary').should('not.contain', text)
+  }
 }

--- a/integration_tests/tests/apply/before_you_apply/cohort-selection/cohort-selection.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/cohort-selection/cohort-selection.cy.ts
@@ -102,4 +102,42 @@ context('Complete Cohort selection task in "Before you apply" section', () => {
       licencePage.verifyUpdate(updatedApplication)
     })
   })
+
+  it('Removes orphaned data', () => {
+    cy.task('stubApplicationGet', { application })
+    cy.task('stubApplicationUpdate', { application })
+
+    // Given I am on the cohort selection page
+    const cohortPage = CohortSelectionPage.visit(application)
+
+    // When I select cohort 'atcr'
+    cohortPage.selectCohort('atcr')
+
+    // Then I am on the licence dates page
+    const licencePage = new LicenceDatesPage(application)
+    licencePage.completeForm('atcr')
+
+    // When I complete the dates including hdcExpiry
+    licencePage.clickSubmit('Save and continue')
+    cy.task('stubApplicationGetFromLastUpdate', { application })
+
+    // And I return to the cohort page and switch to 'hcrd'
+    cohortPage.selectCohort('rarr')
+
+    // And I return to the cohort page and switch to 'atcr' again
+    cohortPage.selectCohort('atcr')
+
+    // When I submit the page
+    licencePage.clickSubmit('Save and continue')
+
+    // Then I see errors because the start date and hdc radion have been cleared
+    licencePage.shouldShowErrorSummary('Licence start date must be entered')
+    licencePage.shouldShowErrorSummary('Select yes if they have a HDC expiry date')
+
+    // When I select yes to the HDC expiry date
+    licencePage.checkRadioByNameAndValue('hasHdcExpiryDate', 'yes')
+    licencePage.clickSubmit('Save and continue')
+    // Then I can see that the hdc expiry date has been cleared too
+    licencePage.shouldShowErrorSummary('HDC expiry date must be entered')
+  })
 })

--- a/integration_tests/tests/apply/before_you_apply/cohort-selection/cohort-selection.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/cohort-selection/cohort-selection.cy.ts
@@ -3,6 +3,8 @@ import { faker } from '@faker-js/faker'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 import CohortSelectionPage from '../../../../pages/apply/before_you_apply/cohort-selection/cohortSelection'
 import { cohortSelectionAnswers } from '../../../../../server/utils/applications/cohortLabels'
+import LicenceDatesPage from '../../../../pages/apply/before_you_apply/cohort-selection/licenceDates'
+import LicenceDatesNeededPage from '../../../../pages/apply/before_you_apply/cohort-selection/licenceDatesNeededPage'
 
 context('Complete Cohort selection task in "Before you apply" section', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
@@ -14,6 +16,7 @@ context('Complete Cohort selection task in "Before you apply" section', () => {
         person,
         data: { ...applicationData, 'cohort-selection': undefined },
         applicationOrigin: 'other',
+        cohort: undefined,
       })
     })
 
@@ -26,7 +29,7 @@ context('Complete Cohort selection task in "Before you apply" section', () => {
   it('allows the cohort to be selected', () => {
     cy.task('stubApplicationGet', { application })
     cy.task('stubApplicationUpdate', { application })
-    const newCohort = faker.helpers.arrayElement(Object.keys(cohortSelectionAnswers)) as Cas2CohortDto
+    const newCohort: Cas2CohortDto = faker.helpers.arrayElement(Object.keys(cohortSelectionAnswers)) as Cas2CohortDto
 
     // Given I am on the cohort selection page
     const page = CohortSelectionPage.visit(application)
@@ -50,12 +53,53 @@ context('Complete Cohort selection task in "Before you apply" section', () => {
     })
     page.clickSubmit('Confirm and continue')
 
-    // Then I am redirected back to the tasklist with everything completed
-    cy.contains('You have completed 18 of 18 tasks.')
-
-    // And the application cohort is updated
+    // Then the application cohort is updated
     cy.task('verifyApplicationUpdate', application.id).then(requests => {
       expect(JSON.parse(requests[0].body).cohort).eq(newCohort)
+    })
+  })
+
+  it('allows the licence dates to be entered', () => {
+    cy.task('stubApplicationGet', { application })
+    cy.task('stubApplicationUpdate', { application })
+    const testCohorts: Array<Cas2CohortDto> = ['atcr', 'hcrd', 'isc']
+    testCohorts.forEach((cohort: Cas2CohortDto) => {
+      // Given I am on the cohort selection page
+      const cohortPage = CohortSelectionPage.visit(application)
+
+      // And I select a cohort
+      cohortPage.checkRadioByNameAndValue('cohort', cohort)
+      const updatedApplication = {
+        ...application,
+        cohort,
+        data: { ...application.data, 'cohort-selection': { 'cohort-selection': { cohort } } },
+      }
+      cy.task('stubApplicationGet', { application: updatedApplication })
+
+      // And submit
+      cohortPage.clickSubmit('Confirm and continue')
+
+      if (cohort === 'isc') {
+        // Then I see the intermediate page
+        const licenceNeededPage = new LicenceDatesNeededPage(application)
+
+        // When I answer yes and submit
+        licenceNeededPage.answerYes()
+      }
+      // Then I am on the licence dates page
+      const licencePage = new LicenceDatesPage(application)
+
+      // When I submit the empty form
+      licencePage.clickSubmit('Save and continue')
+
+      // Then I should see errors
+      licencePage.shouldSeeErrrors(cohort)
+
+      // When I complete the form and submit
+      licencePage.completeForm(cohort)
+      licencePage.clickSubmit('Save and continue')
+      // Then the correct dates will have been posted
+      licencePage.verifyUpdate(updatedApplication)
     })
   })
 })

--- a/integration_tests/tests/apply/before_you_apply/solicitor-details/solicitor-details.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/solicitor-details/solicitor-details.cy.ts
@@ -5,6 +5,7 @@ import Page from '../../../../pages/page'
 import HasSolicitorPage from '../../../../pages/apply/before_you_apply/solicitor-details/hasSolicitor'
 import Chainable = Cypress.Chainable
 import SolicitorDetailsPage from '../../../../pages/apply/before_you_apply/solicitor-details/solicitorDetails'
+import { isoDateToDateParts } from '../../../../../server/utils/dateUtils'
 
 context('Complete "Add solicitor details" task in "Before you apply" section', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
@@ -20,7 +21,18 @@ context('Complete "Add solicitor details" task in "Before you apply" section', (
     return cy.fixture('applicationData.json').then(applicationData => {
       return applicationFactory.build({
         person,
-        data: { ...applicationData, 'cohort-selection': { 'cohort-selection': { cohort } } },
+        data: {
+          ...applicationData,
+          'cohort-selection': {
+            'cohort-selection': { cohort },
+            'licence-dates': {
+              ...isoDateToDateParts('2026-05-03', 'licenceStartDate'),
+              ...isoDateToDateParts('2026-07-12', 'licenceEndDate'),
+              hasHdcExpiryDate: 'no',
+            },
+          },
+        },
+        cohort,
         applicationOrigin: !['courtBail', 'prisonBail'].includes(cohort) ? 'other' : (cohort as ApplicationOrigin),
       })
     })

--- a/server/controllers/apply/applications/pagesController.ts
+++ b/server/controllers/apply/applications/pagesController.ts
@@ -27,7 +27,6 @@ export default class PagesController {
         const Page = getPage(taskName, pageName, 'applications')
         const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
         const page = await this.applicationService.initializePage(Page, req, this.dataServices, userInput)
-
         res.render(viewPath(page, 'applications'), {
           applicationId: req.params.id,
           errors,

--- a/server/form-pages/apply/before-you-start/cohort-selection/cohortSelection.test.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/cohortSelection.test.ts
@@ -14,8 +14,9 @@ describe('ConsentRefused', () => {
   })
 
   describe('Routing', () => {
-    itShouldHaveNextValue(new CohortSelection(bodyEmpty, application), '')
+    itShouldHaveNextValue(new CohortSelection(bodyEmpty, application), 'licence-dates')
     itShouldHavePreviousValue(new CohortSelection(bodyEmpty, application), 'taskList')
+    itShouldHaveNextValue(new CohortSelection(bodyIsc, application), 'licence-dates-needed')
   })
 
   describe('errors', () => {

--- a/server/form-pages/apply/before-you-start/cohort-selection/cohortSelection.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/cohortSelection.ts
@@ -45,7 +45,7 @@ export default class CohortSelection implements TaskListPage {
   }
 
   next() {
-    return ''
+    return this.body.cohort === 'isc' ? 'licence-dates-needed' : 'licence-dates'
   }
 
   errors() {

--- a/server/form-pages/apply/before-you-start/cohort-selection/cohortSelection.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/cohortSelection.ts
@@ -1,8 +1,7 @@
-import { Radio, TaskListErrors } from '@approved-premises/ui'
+import { TaskListErrors } from '@approved-premises/ui'
 import { Cas2v2Application as Application } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 import TaskListPage from '../../../taskListPage'
-import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { getQuestions } from '../../../utils/questions'
 import { NonBailCohort } from '../../../../utils/applications/cohortLabels'
@@ -54,10 +53,6 @@ export default class CohortSelection implements TaskListPage {
       errors.cohort = `Select why ${this.personName} needs CAS2 accommodation`
     }
     return errors
-  }
-
-  items() {
-    return convertKeyValuePairToRadioItems(this.questions.cohort.answers, this.body.cohort) as Array<Radio>
   }
 
   response() {

--- a/server/form-pages/apply/before-you-start/cohort-selection/index.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/index.ts
@@ -2,10 +2,12 @@
 
 import { Task } from '../../../utils/decorators'
 import CohortSelection from './cohortSelection'
+import LicenceDatesNeeded from './licence-dates-needed'
+import LicenceDates from './licence-dates'
 
 @Task({
-  name: 'Type of application',
+  name: 'Type of application and licence details',
   slug: 'cohort-selection',
-  pages: [CohortSelection],
+  pages: [CohortSelection, LicenceDatesNeeded, LicenceDates],
 })
 export default class CohortSelectionTask {}

--- a/server/form-pages/apply/before-you-start/cohort-selection/licence-dates-needed.test.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/licence-dates-needed.test.ts
@@ -1,0 +1,56 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { applicationFactory, personFactory } from '../../../../testutils/factories'
+import LicenceDatesNeeded from './licence-dates-needed'
+
+describe('LicenceDatesNeeded', () => {
+  const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
+
+  const page = new LicenceDatesNeeded({}, application)
+  const yesPage = new LicenceDatesNeeded({ licenceDatesNeeded: 'yes' }, application)
+
+  describe('questions', () => {
+    it('Returns the correct questions', () => {
+      expect(page.questions).toEqual({ licenceDatesNeeded: 'Is Roger Smith on licence for a different offence?' })
+    })
+  })
+
+  describe('title', () => {
+    it('Has the correct title', () => {
+      expect(page.title).toEqual('Is Roger Smith on licence for a different offence?')
+    })
+  })
+
+  describe('Routing', () => {
+    itShouldHaveNextValue(page, '')
+    itShouldHavePreviousValue(page, 'cohort-selection')
+  })
+
+  describe('Errors', () => {
+    it('Returns error if the question is not answered', () => {
+      expect(page.errors()).toEqual({
+        licenceDatesNeeded: 'Select yes if Roger Smith is on licence for a different offence',
+      })
+    })
+
+    it('Returns no error if the question is answered', () => {
+      expect(yesPage.errors()).toEqual({})
+    })
+  })
+
+  describe('items', () => {
+    it('returns the radio with the expected label text', () => {
+      expect(yesPage.items()).toEqual([
+        {
+          checked: true,
+          text: 'Yes',
+          value: 'yes',
+        },
+        {
+          checked: false,
+          text: 'No',
+          value: 'no',
+        },
+      ])
+    })
+  })
+})

--- a/server/form-pages/apply/before-you-start/cohort-selection/licence-dates-needed.test.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/licence-dates-needed.test.ts
@@ -10,7 +10,16 @@ describe('LicenceDatesNeeded', () => {
 
   describe('questions', () => {
     it('Returns the correct questions', () => {
-      expect(page.questions).toEqual({ licenceDatesNeeded: 'Is Roger Smith on licence for a different offence?' })
+      expect(page.questions).toEqual({
+        licenceDatesNeeded: {
+          answers: {
+            no: 'No',
+            yes: 'Yes',
+          },
+          dataType: 'radio',
+          question: 'Is Roger Smith on licence for a different offence?',
+        },
+      })
     })
   })
 
@@ -37,20 +46,23 @@ describe('LicenceDatesNeeded', () => {
     })
   })
 
-  describe('items', () => {
-    it('returns the radio with the expected label text', () => {
-      expect(yesPage.items()).toEqual([
-        {
-          checked: true,
-          text: 'Yes',
-          value: 'yes',
-        },
-        {
-          checked: false,
-          text: 'No',
-          value: 'no',
-        },
-      ])
+  describe('response', () => {
+    it('Returns the correct response', () => {
+      expect(yesPage.response()).toEqual({
+        'Is Roger Smith on licence for a different offence?': 'Yes',
+      })
+    })
+  })
+
+  describe('isApplicable', () => {
+    it('should only be applicable for "other" applicationOrigin', () => {
+      const testPage = new LicenceDatesNeeded({}, { ...application, applicationOrigin: 'other' })
+      expect(testPage.isApplicable()).toEqual(true)
+    })
+
+    it('should not be applicable if origin is not "other"', () => {
+      const testPage = new LicenceDatesNeeded({}, { ...application, applicationOrigin: 'courtBail' })
+      expect(testPage.isApplicable()).toEqual(false)
     })
   })
 })

--- a/server/form-pages/apply/before-you-start/cohort-selection/licence-dates-needed.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/licence-dates-needed.ts
@@ -1,0 +1,68 @@
+import { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { Cas2v2Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
+import { nameOrPlaceholderCopy } from '../../../../utils/utils'
+import { getQuestions } from '../../../utils/questions'
+
+type LicenceDatesNeededBody = {
+  licenceDatesNeeded: YesOrNo
+}
+
+@Page({
+  name: 'licence-dates-needed',
+  bodyProperties: ['licenceDatesNeeded'],
+})
+export default class LicenceDatesNeeded implements TaskListPage {
+  isOtherCohort = this.application.applicationOrigin === 'other'
+
+  documentTitle = 'Licence dates needed'
+
+  personName = nameOrPlaceholderCopy(this.application.person)
+
+  title = `Is ${this.personName} on licence for a different offence?`
+
+  questions: Record<string, string>
+
+  options: Record<string, string>
+
+  body: { licenceDatesNeeded: YesOrNo }
+
+  constructor(
+    body: Partial<LicenceDatesNeededBody>,
+    private readonly application: Cas2v2Application,
+  ) {
+    this.body = body as LicenceDatesNeededBody
+
+    const applicationQuestions = getQuestions(this.personName)
+    this.questions = {
+      licenceDatesNeeded: applicationQuestions.licence['licence-dates-needed'].licenceDatesNeeded.question,
+    }
+    this.options = applicationQuestions.licence['licence-dates-needed'].licenceDatesNeeded.answers
+  }
+
+  previous() {
+    return 'cohort-selection'
+  }
+
+  next() {
+    return this.body.licenceDatesNeeded === 'yes' ? 'licence-dates' : ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+    if (!this.body.licenceDatesNeeded) {
+      errors.licenceDatesNeeded = `Select yes if ${this.personName} is on licence for a different offence`
+    }
+    return errors
+  }
+
+  items() {
+    return convertKeyValuePairToRadioItems(this.options, this.body.licenceDatesNeeded)
+  }
+
+  isApplicable() {
+    return this.application.applicationOrigin === 'other'
+  }
+}

--- a/server/form-pages/apply/before-you-start/cohort-selection/licence-dates-needed.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/licence-dates-needed.ts
@@ -1,10 +1,9 @@
 import { TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import { Cas2v2Application } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
-import TaskListPage from '../../../taskListPage'
-import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { getQuestions } from '../../../utils/questions'
+import BasePage from '../../../utils/basePage'
 
 type LicenceDatesNeededBody = {
   licenceDatesNeeded: YesOrNo
@@ -14,32 +13,24 @@ type LicenceDatesNeededBody = {
   name: 'licence-dates-needed',
   bodyProperties: ['licenceDatesNeeded'],
 })
-export default class LicenceDatesNeeded implements TaskListPage {
+export default class LicenceDatesNeeded extends BasePage {
   isOtherCohort = this.application.applicationOrigin === 'other'
 
   documentTitle = 'Licence dates needed'
 
   personName = nameOrPlaceholderCopy(this.application.person)
 
-  title = `Is ${this.personName} on licence for a different offence?`
-
-  questions: Record<string, string>
-
-  options: Record<string, string>
-
-  body: { licenceDatesNeeded: YesOrNo }
+  body: LicenceDatesNeededBody
 
   constructor(
     body: Partial<LicenceDatesNeededBody>,
     private readonly application: Cas2v2Application,
   ) {
+    super()
     this.body = body as LicenceDatesNeededBody
 
-    const applicationQuestions = getQuestions(this.personName)
-    this.questions = {
-      licenceDatesNeeded: applicationQuestions.licence['licence-dates-needed'].licenceDatesNeeded.question,
-    }
-    this.options = applicationQuestions.licence['licence-dates-needed'].licenceDatesNeeded.answers
+    this.questions = getQuestions(this.personName)['cohort-selection']['licence-dates-needed']
+    this.title = this.questions.licenceDatesNeeded.question
   }
 
   previous() {
@@ -56,10 +47,6 @@ export default class LicenceDatesNeeded implements TaskListPage {
       errors.licenceDatesNeeded = `Select yes if ${this.personName} is on licence for a different offence`
     }
     return errors
-  }
-
-  items() {
-    return convertKeyValuePairToRadioItems(this.options, this.body.licenceDatesNeeded)
   }
 
   isApplicable() {

--- a/server/form-pages/apply/before-you-start/cohort-selection/licence-dates.test.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/licence-dates.test.ts
@@ -1,0 +1,120 @@
+import { Cas2CohortDto } from 'server/@types/shared'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { applicationFactory, personFactory } from '../../../../testutils/factories'
+import LicenceDates, { LicenceDatesBody } from './licence-dates'
+
+describe('LicenceDates', () => {
+  const application = applicationFactory.build({ cohort: 'atcr', person: personFactory.build({ name: 'Roger Smith' }) })
+
+  const page = (cohort: Cas2CohortDto, body = {} as LicenceDatesBody) =>
+    new LicenceDates(body, { ...application, cohort })
+
+  const dateToDateParts = (isoDate: string, key: string) => {
+    const [year, month, day] = isoDate.split('-')
+    return { [`${key}-day`]: day, [`${key}-month`]: month, [`${key}-year`]: year }
+  }
+
+  const filledBody: Partial<LicenceDatesBody> = {
+    ...dateToDateParts('2026-05-03', 'licenceStartDate'),
+    ...dateToDateParts('2026-07-12', 'licenceEndDate'),
+    ...dateToDateParts('2026-10-03', 'hdcExpiryDate'),
+    hasHdcExpiryDate: 'yes',
+  }
+
+  describe('questions', () => {
+    const allQuestions = {
+      hasHdcExpiryDate: 'Does Roger Smith have an HDC expiry date?',
+      hdcExpiryDate: 'HDC expiry date',
+      licenceEndDate: "What is Roger Smith's licence end date?",
+      licenceStartDate: "What is Roger Smith's licence start date/conditional release date?",
+    }
+    const tests: Array<[Cas2CohortDto, object]> = [
+      ['hcrd', { ...allQuestions, hasHdcExpiryDate: undefined }],
+      ['atcr', { ...allQuestions }],
+      ['hefr', { ...allQuestions, hasHdcExpiryDate: undefined }],
+      ['isc', { ...allQuestions, hasHdcExpiryDate: undefined }],
+      ['rarr', { ...allQuestions, hasHdcExpiryDate: undefined, licenceStartDate: undefined }],
+      ['from_ap', { ...allQuestions, hasHdcExpiryDate: undefined }],
+    ]
+
+    it.each(tests)('Returns the correct questions for cohort %s', (cohort, expected) => {
+      expect(page(cohort as Cas2CohortDto).questions).toEqual(expected)
+    })
+  })
+
+  describe('title', () => {
+    it('Has the correct title', () => {
+      expect(page('isc').title).toEqual("Roger Smith's licence")
+    })
+  })
+
+  describe('Routing', () => {
+    itShouldHaveNextValue(page('rarr'), '')
+    itShouldHavePreviousValue(page('rarr'), 'cohort-selection')
+    itShouldHavePreviousValue(page('isc'), 'licence-dates-needed')
+  })
+
+  describe('Errors', () => {
+    it('Returns errors if the form is blank', () => {
+      expect(page('isc').errors()).toEqual({
+        licenceEndDate: 'Licence end date must be entered',
+        licenceStartDate: 'Licence start date must be entered',
+      })
+    })
+
+    it('Requires hdc expiry date as well if hdc question is answered', () => {
+      expect(page('atcr', { ...filledBody, 'hdcExpiryDate-month': undefined } as LicenceDatesBody).errors()).toEqual({
+        hdcExpiryDate: 'HDC expiry date must be entered',
+      })
+    })
+
+    it('Does not require hdc expiry date if hdc question is answered "no"', () => {
+      expect(
+        page('atcr', { ...filledBody, hasHdcExpiryDate: 'no', 'hdcExpiryDate-month': '' } as LicenceDatesBody).errors(),
+      ).toEqual({})
+    })
+
+    it('Returns no errors if all questions are answered', () => {
+      expect(new LicenceDates(filledBody, application).errors()).toEqual({})
+    })
+  })
+
+  describe('onSave', () => {
+    it('does nothing if hasHdcExpiryDate is "yes"', () => {
+      const testBody = { ...filledBody, hasHdcExpiryDate: 'yes' } as LicenceDatesBody
+      const testPage = new LicenceDates(testBody, application)
+      testPage.onSave()
+      expect(testPage.body).toEqual(testBody)
+    })
+
+    it('wipes the hdcExpiryDate if hasHdcExpiryDate is "no"', () => {
+      const testBody = { ...filledBody, hasHdcExpiryDate: 'no' } as LicenceDatesBody
+      const testPage = new LicenceDates(testBody, application)
+      testPage.onSave()
+      expect(testPage.body).toEqual({
+        ...testBody,
+        'hdcExpiryDate-day': undefined,
+        'hdcExpiryDate-month': undefined,
+        'hdcExpiryDate-year': undefined,
+      })
+    })
+  })
+
+  describe('items', () => {
+    it('returns the radio with the expected label text and conditional content injected', () => {
+      expect(page('hcrd').hdcRadioItems({ yes: { html: '<Conditional html>' } })).toEqual([
+        {
+          checked: false,
+          text: 'Yes',
+          value: 'yes',
+          conditional: { html: '<Conditional html>' },
+        },
+        {
+          checked: false,
+          text: 'No',
+          value: 'no',
+        },
+      ])
+    })
+  })
+})

--- a/server/form-pages/apply/before-you-start/cohort-selection/licence-dates.test.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/licence-dates.test.ts
@@ -3,6 +3,7 @@ import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../share
 import { applicationFactory, personFactory } from '../../../../testutils/factories'
 import LicenceDates, { LicenceDatesBody } from './licence-dates'
 import { getQuestions } from '../../../utils/questions'
+import { isoDateToDateParts } from '../../../../utils/dateUtils'
 
 describe('LicenceDates', () => {
   const application = applicationFactory.build({ cohort: 'atcr', person: personFactory.build({ name: 'Roger Smith' }) })
@@ -10,15 +11,10 @@ describe('LicenceDates', () => {
   const page = (cohort: Cas2CohortDto, body = {} as LicenceDatesBody) =>
     new LicenceDates(body, { ...application, cohort })
 
-  const dateToDateParts = (isoDate: string, key: string) => {
-    const [year, month, day] = isoDate.split('-')
-    return { [`${key}-day`]: day, [`${key}-month`]: month, [`${key}-year`]: year }
-  }
-
   const filledBody: Partial<LicenceDatesBody> = {
-    ...dateToDateParts('2026-05-03', 'licenceStartDate'),
-    ...dateToDateParts('2026-07-12', 'licenceEndDate'),
-    ...dateToDateParts('2026-10-03', 'hdcExpiryDate'),
+    ...isoDateToDateParts('2026-05-03', 'licenceStartDate'),
+    ...isoDateToDateParts('2026-07-12', 'licenceEndDate'),
+    ...isoDateToDateParts('2026-10-03', 'hdcExpiryDate'),
     hasHdcExpiryDate: 'yes',
   }
 

--- a/server/form-pages/apply/before-you-start/cohort-selection/licence-dates.test.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/licence-dates.test.ts
@@ -2,6 +2,7 @@ import { Cas2CohortDto } from 'server/@types/shared'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import { applicationFactory, personFactory } from '../../../../testutils/factories'
 import LicenceDates, { LicenceDatesBody } from './licence-dates'
+import { getQuestions } from '../../../utils/questions'
 
 describe('LicenceDates', () => {
   const application = applicationFactory.build({ cohort: 'atcr', person: personFactory.build({ name: 'Roger Smith' }) })
@@ -22,12 +23,8 @@ describe('LicenceDates', () => {
   }
 
   describe('questions', () => {
-    const allQuestions = {
-      hasHdcExpiryDate: 'Does Roger Smith have an HDC expiry date?',
-      hdcExpiryDate: 'HDC expiry date',
-      licenceEndDate: "What is Roger Smith's licence end date?",
-      licenceStartDate: "What is Roger Smith's licence start date/conditional release date?",
-    }
+    const allQuestions = getQuestions('Roger Smith')['cohort-selection']['licence-dates']
+
     const tests: Array<[Cas2CohortDto, object]> = [
       ['hcrd', { ...allQuestions, hasHdcExpiryDate: undefined }],
       ['atcr', { ...allQuestions }],
@@ -56,9 +53,10 @@ describe('LicenceDates', () => {
 
   describe('Errors', () => {
     it('Returns errors if the form is blank', () => {
-      expect(page('isc').errors()).toEqual({
+      expect(page('atcr').errors()).toEqual({
         licenceEndDate: 'Licence end date must be entered',
         licenceStartDate: 'Licence start date must be entered',
+        hasHdcExpiryDate: 'Select yes if they have a HDC expiry date',
       })
     })
 
@@ -100,21 +98,28 @@ describe('LicenceDates', () => {
     })
   })
 
-  describe('items', () => {
-    it('returns the radio with the expected label text and conditional content injected', () => {
-      expect(page('hcrd').hdcRadioItems({ yes: { html: '<Conditional html>' } })).toEqual([
-        {
-          checked: false,
-          text: 'Yes',
-          value: 'yes',
-          conditional: { html: '<Conditional html>' },
-        },
-        {
-          checked: false,
-          text: 'No',
-          value: 'no',
-        },
-      ])
+  describe('response', () => {
+    it('Returns the correct response', () => {
+      const testPage = new LicenceDates(filledBody, application)
+
+      expect(testPage.response()).toEqual({
+        'Does Roger Smith have an HDC expiry date?': 'Yes',
+        'HDC expiry date': '3 October 2026',
+        "What is Roger Smith's licence end date?": '12 July 2026',
+        "What is Roger Smith's licence start date/conditional release date?": '3 May 2026',
+      })
+    })
+  })
+
+  describe('isApplicable', () => {
+    it('should only be applicable for "other" applicationOrigin', () => {
+      const testPage = new LicenceDates({}, { ...application, applicationOrigin: 'other' })
+      expect(testPage.isApplicable()).toEqual(true)
+    })
+
+    it('should not be applicable if origin is not "other"', () => {
+      const testPage = new LicenceDates({}, { ...application, applicationOrigin: 'courtBail' })
+      expect(testPage.isApplicable()).toEqual(false)
     })
   })
 })

--- a/server/form-pages/apply/before-you-start/cohort-selection/licence-dates.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/licence-dates.ts
@@ -1,0 +1,105 @@
+import { Cas2v2Application } from '@approved-premises/api'
+import { ObjectWithDateParts, Radio, RadioItem, TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { Page } from '../../../utils/decorators'
+import TaskListPage from '../../../taskListPage'
+import { convertKeyValuePairToRadioItems, validateDateParts } from '../../../../utils/formUtils'
+import { nameOrPlaceholderCopy } from '../../../../utils/utils'
+import { getQuestions } from '../../../utils/questions'
+import { dateBodyProperties } from '../../../utils'
+
+export type LicenceDatesBody = {
+  hasHdcExpiryDate: YesOrNo
+} & ObjectWithDateParts<'licenceStartDate'> &
+  ObjectWithDateParts<'licenceEndDate'> &
+  ObjectWithDateParts<'hdcExpiryDate'>
+
+@Page({
+  name: 'licence-dates',
+  bodyProperties: [
+    'hasHdcExpiryDate',
+    ...dateBodyProperties('licenceStartDate'),
+    ...dateBodyProperties('licenceEndDate'),
+    ...dateBodyProperties('hdcExpiryDate'),
+  ],
+})
+export default class LicenceDates implements TaskListPage {
+  isOtherCohort = this.application.applicationOrigin === 'other'
+
+  documentTitle = 'Licence dates needed'
+
+  personName = nameOrPlaceholderCopy(this.application.person)
+
+  title = `${this.personName}'s licence`
+
+  questions: Record<string, string>
+
+  options: Record<string, Array<RadioItem>>
+
+  body: LicenceDatesBody
+
+  constructor(
+    body: Partial<LicenceDatesBody>,
+    private readonly application: Cas2v2Application,
+  ) {
+    this.body = body as LicenceDatesBody
+
+    const applicationQuestions = getQuestions(this.personName).licence['licence-dates']
+    this.questions = Object.entries(applicationQuestions).reduce(
+      (out, [key, question]) => ({ ...out, [key]: question.question }),
+      {},
+    )
+    if (application.cohort === 'rarr') this.questions.licenceStartDate = undefined
+    if (application.cohort !== 'atcr') this.questions.hasHdcExpiryDate = undefined
+
+    this.options = {
+      hasHdcExpiryDate: convertKeyValuePairToRadioItems(
+        applicationQuestions.hasHdcExpiryDate.answers,
+        this.body.hasHdcExpiryDate,
+      ),
+    }
+  }
+
+  previous() {
+    return this.application.cohort === 'isc' ? 'licence-dates-needed' : 'cohort-selection'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    return {
+      ...(this.questions.licenceStartDate
+        ? validateDateParts<LicenceDatesBody>('licenceStartDate', 'Licence start date', this.body)
+        : {}),
+      ...validateDateParts<LicenceDatesBody>('licenceEndDate', 'Licence end date', this.body, { future: true }),
+      ...(this.questions.hasHdcExpiryDate && this.body.hasHdcExpiryDate === 'yes'
+        ? validateDateParts<LicenceDatesBody>('hdcExpiryDate', 'HDC expiry date', this.body)
+        : ({} as TaskListErrors<LicenceDates>)),
+      ...(this.questions.hasHdcExpiryDate && !this.body.hasHdcExpiryDate
+        ? { hasHdcExpiryDate: 'Select yes if they have a HDC expiry date' }
+        : {}),
+    } as TaskListErrors<this>
+  }
+
+  onSave() {
+    if (this.body.hasHdcExpiryDate === 'no') {
+      delete this.body['hdcExpiryDate-year']
+      delete this.body['hdcExpiryDate-month']
+      delete this.body['hdcExpiryDate-day']
+    }
+  }
+
+  isApplicable() {
+    return this.application.applicationOrigin === 'other'
+  }
+
+  hdcRadioItems(conditionals: Record<string, unknown>) {
+    return this.options.hasHdcExpiryDate.map(option => {
+      return {
+        ...option,
+        conditional: conditionals[(option as Radio).value],
+      }
+    })
+  }
+}

--- a/server/form-pages/apply/before-you-start/cohort-selection/licence-dates.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/licence-dates.ts
@@ -1,8 +1,8 @@
 import { Cas2v2Application } from '@approved-premises/api'
-import { ObjectWithDateParts, Radio, RadioItem, TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { ObjectWithDateParts, TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import { Page } from '../../../utils/decorators'
-import TaskListPage from '../../../taskListPage'
-import { convertKeyValuePairToRadioItems, validateDateParts } from '../../../../utils/formUtils'
+import BasePage from '../../../utils/basePage'
+import { validateDateParts } from '../../../../utils/formUtils'
 import { nameOrPlaceholderCopy } from '../../../../utils/utils'
 import { getQuestions } from '../../../utils/questions'
 import { dateBodyProperties } from '../../../utils'
@@ -22,7 +22,7 @@ export type LicenceDatesBody = {
     ...dateBodyProperties('hdcExpiryDate'),
   ],
 })
-export default class LicenceDates implements TaskListPage {
+export default class LicenceDates extends BasePage {
   isOtherCohort = this.application.applicationOrigin === 'other'
 
   documentTitle = 'Licence dates needed'
@@ -31,40 +31,24 @@ export default class LicenceDates implements TaskListPage {
 
   title = `${this.personName}'s licence`
 
-  questions: Record<string, string>
-
-  options: Record<string, Array<RadioItem>>
-
   body: LicenceDatesBody
 
   constructor(
     body: Partial<LicenceDatesBody>,
     private readonly application: Cas2v2Application,
   ) {
+    super()
+
     this.body = body as LicenceDatesBody
 
-    const applicationQuestions = getQuestions(this.personName).licence['licence-dates']
-    this.questions = Object.entries(applicationQuestions).reduce(
-      (out, [key, question]) => ({ ...out, [key]: question.question }),
-      {},
-    )
+    this.questions = getQuestions(this.personName)['cohort-selection']['licence-dates']
+
     if (application.cohort === 'rarr') this.questions.licenceStartDate = undefined
     if (application.cohort !== 'atcr') this.questions.hasHdcExpiryDate = undefined
-
-    this.options = {
-      hasHdcExpiryDate: convertKeyValuePairToRadioItems(
-        applicationQuestions.hasHdcExpiryDate.answers,
-        this.body.hasHdcExpiryDate,
-      ),
-    }
   }
 
   previous() {
     return this.application.cohort === 'isc' ? 'licence-dates-needed' : 'cohort-selection'
-  }
-
-  next() {
-    return ''
   }
 
   errors() {
@@ -92,14 +76,5 @@ export default class LicenceDates implements TaskListPage {
 
   isApplicable() {
     return this.application.applicationOrigin === 'other'
-  }
-
-  hdcRadioItems(conditionals: Record<string, unknown>) {
-    return this.options.hasHdcExpiryDate.map(option => {
-      return {
-        ...option,
-        conditional: conditionals[(option as Radio).value],
-      }
-    })
   }
 }

--- a/server/form-pages/apply/offences-and-concerns/provide-offences-and-convictions-details/offencesAndConvictionsGuidance.ts
+++ b/server/form-pages/apply/offences-and-concerns/provide-offences-and-convictions-details/offencesAndConvictionsGuidance.ts
@@ -22,7 +22,7 @@ export default class OffencesAndConvictionsGuidance implements TaskListPage {
 
   questions = getQuestions(this.personName)['provide-offences-and-convictions-details'][
     'offences-and-convictions-guidance'
-  ]
+  ].offencesAndConvictionsGuidance
 
   constructor(
     body: Partial<OffencesAndConvictionsGuidanceBody>,

--- a/server/form-pages/utils/basePage.test.ts
+++ b/server/form-pages/utils/basePage.test.ts
@@ -1,0 +1,40 @@
+import BasePage from './basePage'
+
+describe('basePage', () => {
+  it('should default the previous and next methods', () => {
+    const page = new BasePage()
+    expect(page.next()).toEqual('')
+    expect(page.previous()).toEqual('')
+  })
+
+  it('should generate a response from the questions', () => {
+    const questions = {
+      q1: {
+        question: `label for question 1`,
+        dataType: 'date',
+      },
+      q2: {
+        question: `label for question 2`,
+        dataType: 'radio',
+        answers: { answer1: 'Answer 1', answer2: 'Answer 2' },
+      },
+      q3: {
+        question: `Unanswered question will be omitted`,
+        dataType: 'textArea',
+      },
+    }
+    const body = {
+      'q1-year': '2026',
+      'q1-month': '6',
+      'q1-day': '13',
+      q2: 'answer2',
+    }
+    const page = new BasePage()
+    page.questions = questions
+    page.body = body
+    expect(page.response()).toEqual({
+      'label for question 1': '13 June 2026',
+      'label for question 2': 'Answer 2',
+    })
+  })
+})

--- a/server/form-pages/utils/basePage.ts
+++ b/server/form-pages/utils/basePage.ts
@@ -1,0 +1,39 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import TaskListPage from '../taskListPage'
+import { DateFormats } from '../../utils/dateUtils'
+import { Question } from './questions'
+
+export default class BasePage implements TaskListPage {
+  documentTitle: string
+
+  title: string
+
+  body: Record<string, unknown>
+
+  questions: Record<string, Question>
+
+  previous() {
+    return ''
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    return [] as TaskListErrors<this>
+  }
+
+  response() {
+    return Object.entries(this.questions).reduce((out, [key, question]) => {
+      let value: string = this.body[key] as string
+      if (question.dataType === 'date') {
+        value = DateFormats.dateAndTimeInputsToUiDate(this.body as Record<string, string>, key)
+      }
+      if (question.answers) {
+        value = question.answers[value]
+      }
+      return value === undefined ? out : { ...out, [question.question]: value }
+    }, {}) as Record<string, string>
+  }
+}

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -87,6 +87,35 @@ export function getQuestions(name: string, isOtherCohort = false) {
         },
       },
     },
+    licence: {
+      'licence-dates-needed': {
+        licenceDatesNeeded: {
+          question: `Is ${name} on licence for a different offence?`,
+          answers: {
+            yes: 'Yes',
+            no: 'No',
+          },
+        },
+      },
+      'licence-dates': {
+        licenceStartDate: {
+          question: `What is ${name}'s licence start date/conditional release date?`,
+        },
+        licenceEndDate: {
+          question: `What is ${name}'s licence end date?`,
+        },
+        hdcExpiryDate: {
+          question: `HDC expiry date`,
+        },
+        hasHdcExpiryDate: {
+          question: `Does ${name} have an HDC expiry date?`,
+          answers: {
+            yes: 'Yes',
+            no: 'No',
+          },
+        },
+      },
+    },
     'referrer-details': {
       'confirm-details': {
         name: { question: 'Name' },

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -1,6 +1,6 @@
 import { cohortSelectionAnswers } from '../../utils/applications/cohortLabels'
 
-export type Question = { question: string; answers?: Record<string, string>; hint?: string }
+export type Question = { question: string; answers?: Record<string, string>; hint?: string; dataType?: string }
 type QuestionsNode = { [property: string]: Question | QuestionsNode }
 export type Questions = ReturnType<typeof getQuestions>
 
@@ -23,7 +23,10 @@ export function getQuestion(questions: Questions, ...categories: string[]): Ques
   return recurse(questions as QuestionsNode, ...categories)
 }
 
-export function getQuestions(name: string, isOtherCohort = false) {
+export function getQuestions(
+  name: string,
+  isOtherCohort = false,
+): Record<string, Record<string, Record<string, Question>>> {
   const yesOrNo = { yes: 'Yes', no: 'No' }
   const yesNoOrIDontKnow = { yes: 'Yes', no: 'No', dontKnow: `I don't know` }
   const riskLevelAnswers = {
@@ -81,31 +84,28 @@ export function getQuestions(name: string, isOtherCohort = false) {
         cohort: {
           question: `Why does ${name} need CAS2 accommodation?`,
           answers: cohortSelectionAnswers,
+          dataType: 'radio',
         },
         notes: {
           question: 'Provide details (optional)',
+          dataType: 'textArea',
         },
       },
-    },
-    licence: {
       'licence-dates-needed': {
         licenceDatesNeeded: {
           question: `Is ${name} on licence for a different offence?`,
-          answers: {
-            yes: 'Yes',
-            no: 'No',
-          },
+          answers: yesOrNo,
+          dataType: 'radio',
         },
       },
       'licence-dates': {
         licenceStartDate: {
           question: `What is ${name}'s licence start date/conditional release date?`,
+          dataType: 'date',
         },
         licenceEndDate: {
           question: `What is ${name}'s licence end date?`,
-        },
-        hdcExpiryDate: {
-          question: `HDC expiry date`,
+          dataType: 'date',
         },
         hasHdcExpiryDate: {
           question: `Does ${name} have an HDC expiry date?`,
@@ -113,6 +113,10 @@ export function getQuestions(name: string, isOtherCohort = false) {
             yes: 'Yes',
             no: 'No',
           },
+        },
+        hdcExpiryDate: {
+          question: `HDC expiry date`,
+          dataType: 'date',
         },
       },
     },
@@ -217,10 +221,7 @@ export function getQuestions(name: string, isOtherCohort = false) {
       'previous-address': {
         hasPreviousAddress: {
           question: `Did ${name} have a fixed address before being arrested?`,
-          answers: {
-            yes: 'Yes',
-            no: 'No',
-          },
+          answers: yesOrNo,
         },
         previousAddress: {
           question: 'Enter their last fixed address',
@@ -1080,7 +1081,9 @@ export function getQuestions(name: string, isOtherCohort = false) {
     },
     'provide-offences-and-convictions-details': {
       'offences-and-convictions-guidance': {
-        question: `${name}'s current alleged offences and previous convictions`,
+        offencesAndConvictionsGuidance: {
+          question: `${name}'s current alleged offences and previous convictions`,
+        },
       },
     },
     'alleged-offences': {

--- a/server/utils/applications/deleteOrphanedData.test.ts
+++ b/server/utils/applications/deleteOrphanedData.test.ts
@@ -1,3 +1,4 @@
+import { Cas2CohortDto } from '@approved-premises/api'
 import deleteOrphanedFollowOnAnswers from './deleteOrphanedData'
 
 describe('deleteOrphanedFollowOnAnswers', () => {
@@ -416,6 +417,55 @@ describe('deleteOrphanedFollowOnAnswers', () => {
           },
         },
       })
+    })
+  })
+
+  describe('Removes orphaned licence data according to cohort', () => {
+    const expandDate = (key: string): Record<string, string> => ({
+      [`${key}-day`]: 'd',
+      [`${key}-month`]: 'm',
+      [`${key}-year`]: 'y',
+    })
+
+    const licenceStarDate = expandDate('licenceStartDate')
+    const licenceEndDate = expandDate('licenceEndDate')
+    const hdcEligibilityDate = { ...expandDate('hdcEligibilityDate'), hasHdcEligibilityDate: 'yes' }
+
+    const allLicenceDates = { ...licenceStarDate, ...licenceEndDate, ...hdcEligibilityDate }
+
+    /* eslint-disable-next-line */
+    const applicationData = (cohort: Cas2CohortDto, licenceDates: Record<string, string>): any => {
+      return {
+        'cohort-selection': {
+          'cohort-selection': { cohort },
+          'licence-dates': { ...licenceDates },
+        },
+      }
+    }
+
+    it('removes the start date and hdcEligiilityDate if cohort is rarr', () => {
+      expect(deleteOrphanedFollowOnAnswers(applicationData('rarr', allLicenceDates))).toEqual(
+        applicationData('rarr', { ...licenceEndDate }),
+      )
+    })
+
+    it('leaves the hdcEligibility date if cohort is atcr', () => {
+      expect(deleteOrphanedFollowOnAnswers(applicationData('atcr', allLicenceDates))).toEqual(
+        applicationData('atcr', allLicenceDates),
+      )
+    })
+
+    it('removes the hdcEligibility date if cohort is hcrd', () => {
+      expect(deleteOrphanedFollowOnAnswers(applicationData('hcrd', allLicenceDates))).toEqual(
+        applicationData('hcrd', { ...licenceEndDate, ...licenceStarDate }),
+      )
+    })
+
+    it('removes all licence dates if licenceDatesNeeded is no', () => {
+      const data = applicationData('isc', allLicenceDates)
+      data['cohort-selection'] = { ...data['cohort-selection'], 'licence-dates-needed': { licenceDatesNeeded: 'no' } }
+      const expected = { 'cohort-selection': { ...data['cohort-selection'], 'licence-dates': undefined as unknown } }
+      expect(deleteOrphanedFollowOnAnswers(data)).toEqual(expected)
     })
   })
 })

--- a/server/utils/applications/deleteOrphanedData.test.ts
+++ b/server/utils/applications/deleteOrphanedData.test.ts
@@ -429,7 +429,7 @@ describe('deleteOrphanedFollowOnAnswers', () => {
 
     const licenceStarDate = expandDate('licenceStartDate')
     const licenceEndDate = expandDate('licenceEndDate')
-    const hdcEligibilityDate = { ...expandDate('hdcEligibilityDate'), hasHdcEligibilityDate: 'yes' }
+    const hdcEligibilityDate = { ...expandDate('hdcExpiryDate'), hasHdcExpiryDate: 'yes' }
 
     const allLicenceDates = { ...licenceStarDate, ...licenceEndDate, ...hdcEligibilityDate }
 
@@ -455,7 +455,7 @@ describe('deleteOrphanedFollowOnAnswers', () => {
       )
     })
 
-    it('removes the hdcEligibility date if cohort is hcrd', () => {
+    it('removes the hdcExpiry date if cohort is hcrd', () => {
       expect(deleteOrphanedFollowOnAnswers(applicationData('hcrd', allLicenceDates))).toEqual(
         applicationData('hcrd', { ...licenceEndDate, ...licenceStarDate }),
       )

--- a/server/utils/applications/deleteOrphanedData.ts
+++ b/server/utils/applications/deleteOrphanedData.ts
@@ -1,4 +1,4 @@
-import { Cas2v2Application } from '@approved-premises/api'
+import { Cas2CohortDto, Cas2v2Application } from '@approved-premises/api'
 import { PreviousConvictionsAnswers } from '../../form-pages/apply/offences-and-concerns/previous-unspent-convictions/anyPreviousConvictions'
 
 export default function deleteOrphanedFollowOnAnswers(
@@ -188,6 +188,31 @@ export default function deleteOrphanedFollowOnAnswers(
     })
   ) {
     deleteOrphanedLearningDifficultiesData()
+  }
+  if (
+    hasOrphanedInformation({
+      taskName: 'cohort-selection',
+      pageName: 'licence-dates-needed',
+      questionKey: 'licenceDatesNeeded',
+      answerToCheck: 'no',
+    })
+  ) {
+    delete applicationData['cohort-selection']?.['licence-dates']
+  }
+  const cohort: Cas2CohortDto = applicationData?.['cohort-selection']?.['cohort-selection']?.cohort
+  if (cohort === 'rarr') {
+    delete applicationData['cohort-selection']?.['licence-dates']?.['licenceStartDate-day']
+    delete applicationData['cohort-selection']?.['licence-dates']?.['licenceStartDate-month']
+    delete applicationData['cohort-selection']?.['licence-dates']?.['licenceStartDate-year']
+  }
+  if (cohort !== 'atcr') {
+    delete applicationData['cohort-selection']?.['licence-dates']?.['hdcEligibilityDate-day']
+    delete applicationData['cohort-selection']?.['licence-dates']?.['hdcEligibilityDate-month']
+    delete applicationData['cohort-selection']?.['licence-dates']?.['hdcEligibilityDate-year']
+    delete applicationData['cohort-selection']?.['licence-dates']?.hasHdcEligibilityDate
+  }
+  if (cohort !== 'isc') {
+    delete applicationData['cohort-selection']?.['licence-dates-needed']?.licenceDatesNeeded
   }
 
   return applicationData

--- a/server/utils/applications/deleteOrphanedData.ts
+++ b/server/utils/applications/deleteOrphanedData.ts
@@ -206,10 +206,10 @@ export default function deleteOrphanedFollowOnAnswers(
     delete applicationData['cohort-selection']?.['licence-dates']?.['licenceStartDate-year']
   }
   if (cohort !== 'atcr') {
-    delete applicationData['cohort-selection']?.['licence-dates']?.['hdcEligibilityDate-day']
-    delete applicationData['cohort-selection']?.['licence-dates']?.['hdcEligibilityDate-month']
-    delete applicationData['cohort-selection']?.['licence-dates']?.['hdcEligibilityDate-year']
-    delete applicationData['cohort-selection']?.['licence-dates']?.hasHdcEligibilityDate
+    delete applicationData['cohort-selection']?.['licence-dates']?.['hdcExpiryDate-day']
+    delete applicationData['cohort-selection']?.['licence-dates']?.['hdcExpiryDate-month']
+    delete applicationData['cohort-selection']?.['licence-dates']?.['hdcExpiryDate-year']
+    delete applicationData['cohort-selection']?.['licence-dates']?.hasHdcExpiryDate
   }
   if (cohort !== 'isc') {
     delete applicationData['cohort-selection']?.['licence-dates-needed']?.licenceDatesNeeded

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -71,10 +71,8 @@ export const addPageAnswersToItemsArray = (params: {
   const PageClass = getPage(task, pageKey)
 
   const body = application?.data?.[task]?.[pageKey]
-
   const page = new PageClass(body, application)
   const response = page.response?.()
-
   if (response) {
     Object.keys(response).forEach((question, index) => {
       if (outputFormat === 'checkYourAnswers') {

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -11,6 +11,7 @@ import {
   differenceInDaysFromToday,
   isBeforeDate,
   dateIsComplete,
+  isoDateToDateParts,
 } from './dateUtils'
 
 jest.mock('date-fns', () => {
@@ -418,6 +419,16 @@ describe('DateFormats', () => {
       }
 
       expect(dateIsComplete(date, 'field')).toEqual(true)
+    })
+  })
+
+  describe('isoDateToDateParts', () => {
+    it('splits an iso date into UI date parts', () => {
+      expect(isoDateToDateParts('2026-05-10', 'test-date')).toEqual({
+        'test-date-day': '10',
+        'test-date-month': '05',
+        'test-date-year': '2026',
+      })
     })
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -302,3 +302,8 @@ export const dateIsComplete = <K extends string | number>(
 
   return allPartsExist
 }
+
+export const isoDateToDateParts = (isoDate: string, key: string) => {
+  const [year, month, day] = isoDate.split('-')
+  return { [`${key}-day`]: day, [`${key}-month`]: month, [`${key}-year`]: year }
+}

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -13,6 +13,8 @@ import {
 import { DateFormats } from './dateUtils'
 
 describe('formutils', () => {
+  const obj = { foo: 'Foo', bar: 'Bar' }
+
   describe('escape', () => {
     it('escapes HTML tags', () => {
       expect(escape('<b>Formatted text</b>')).toEqual('&lt;b&gt;Formatted text&lt;/b&gt;')
@@ -28,129 +30,57 @@ describe('formutils', () => {
   })
 
   describe('convertKeyValuePairToRadioItems', () => {
-    const obj = {
-      foo: 'Foo',
-      bar: 'Bar',
-    }
-
     it('should convert a key value pair to radio items', () => {
       expect(convertKeyValuePairToRadioItems(obj, '')).toEqual([
-        {
-          value: 'foo',
-          text: 'Foo',
-          checked: false,
-        },
-        {
-          value: 'bar',
-          text: 'Bar',
-          checked: false,
-        },
+        { value: 'foo', text: 'Foo', checked: false },
+        { value: 'bar', text: 'Bar', checked: false },
       ])
     })
 
     it('should check the checked item', () => {
       expect(convertKeyValuePairToRadioItems(obj, 'foo')).toEqual([
-        {
-          value: 'foo',
-          text: 'Foo',
-          checked: true,
-        },
-        {
-          value: 'bar',
-          text: 'Bar',
-          checked: false,
-        },
+        { value: 'foo', text: 'Foo', checked: true },
+        { value: 'bar', text: 'Bar', checked: false },
       ])
 
       expect(convertKeyValuePairToRadioItems(obj, 'bar')).toEqual([
-        {
-          value: 'foo',
-          text: 'Foo',
-          checked: false,
-        },
-        {
-          value: 'bar',
-          text: 'Bar',
-          checked: true,
-        },
+        { value: 'foo', text: 'Foo', checked: false },
+        { value: 'bar', text: 'Bar', checked: true },
+      ])
+    })
+
+    it('should inject conditionals from a map', () => {
+      expect(convertKeyValuePairToRadioItems(obj, '', { bar: { html: 'Bar conditional' } })).toEqual([
+        { value: 'foo', text: 'Foo', checked: false },
+        { value: 'bar', text: 'Bar', checked: false, conditional: { html: 'Bar conditional' } },
       ])
     })
   })
 
   describe('convertKeyValuePairToCheckboxItems', () => {
-    const obj = {
-      foo: 'Foo',
-      bar: 'Bar',
-    }
-
     it('should convert a key value pair to checkbox items', () => {
       expect(convertKeyValuePairToCheckboxItems(obj, [])).toEqual([
-        {
-          value: 'foo',
-          text: 'Foo',
-          checked: false,
-        },
-        {
-          value: 'bar',
-          text: 'Bar',
-          checked: false,
-        },
+        { value: 'foo', text: 'Foo', checked: false },
+        { value: 'bar', text: 'Bar', checked: false },
       ])
     })
 
     it('should handle an undefined checkedItems value', () => {
       expect(convertKeyValuePairToCheckboxItems(obj, undefined)).toEqual([
-        {
-          value: 'foo',
-          text: 'Foo',
-          checked: false,
-        },
-        {
-          value: 'bar',
-          text: 'Bar',
-          checked: false,
-        },
+        { value: 'foo', text: 'Foo', checked: false },
+        { value: 'bar', text: 'Bar', checked: false },
       ])
     })
 
     it('should check the checked item', () => {
       expect(convertKeyValuePairToCheckboxItems(obj, ['foo'])).toEqual([
-        {
-          value: 'foo',
-          text: 'Foo',
-          checked: true,
-        },
-        {
-          value: 'bar',
-          text: 'Bar',
-          checked: false,
-        },
-      ])
-
-      expect(convertKeyValuePairToCheckboxItems(obj, ['bar'])).toEqual([
-        {
-          value: 'foo',
-          text: 'Foo',
-          checked: false,
-        },
-        {
-          value: 'bar',
-          text: 'Bar',
-          checked: true,
-        },
+        { value: 'foo', text: 'Foo', checked: true },
+        { value: 'bar', text: 'Bar', checked: false },
       ])
 
       expect(convertKeyValuePairToCheckboxItems(obj, ['foo', 'bar'])).toEqual([
-        {
-          value: 'foo',
-          text: 'Foo',
-          checked: true,
-        },
-        {
-          value: 'bar',
-          text: 'Bar',
-          checked: true,
-        },
+        { value: 'foo', text: 'Foo', checked: true },
+        { value: 'bar', text: 'Bar', checked: true },
       ])
     })
   })

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -1,5 +1,6 @@
 import { createMock } from '@golevelup/ts-jest'
-import { ErrorMessages } from '@approved-premises/ui'
+import { ErrorMessages, type ObjectWithDateParts } from '@approved-premises/ui'
+import { addDays, subDays } from 'date-fns'
 import {
   escape,
   convertKeyValuePairToRadioItems,
@@ -7,7 +8,9 @@ import {
   dateFieldValues,
   summaryListItem,
   isValidEmail,
+  validateDateParts,
 } from './formUtils'
+import { DateFormats } from './dateUtils'
 
 describe('formutils', () => {
   describe('escape', () => {
@@ -290,6 +293,32 @@ describe('formutils', () => {
       'should return true for valid email: %s',
       email => {
         expect(isValidEmail(email)).toBe(true)
+      },
+    )
+  })
+
+  describe('validateDateParts', () => {
+    type BodyType = ObjectWithDateParts<'testDate'>
+    const futureDate = DateFormats.dateObjToIsoDate(addDays(new Date(), 10))
+    const pastDate = DateFormats.dateObjToIsoDate(subDays(new Date(), 10))
+
+    const tests = [
+      ['2026-04-12', {}, {}],
+      ['', { testDate: 'Test date must be entered' }, {}],
+      ['2026-02-29', { testDate: 'Test date must be a real date' }, {}],
+      ['not-a-date', { testDate: 'Test date must be a real date' }, {}],
+      [futureDate, {}, { future: true }],
+      [futureDate, { testDate: 'Test date must be in the past' }, { past: true }],
+      [pastDate, {}, { past: true }],
+      [pastDate, { testDate: 'Test date must be in the future' }, { future: true }],
+    ]
+
+    it.each(tests)(
+      'Date %s',
+      (iso: string, expected: Record<string, string>, options: { future: boolean; past: boolean }) => {
+        const parts = iso.split('-')
+        const body = { 'testDate-day': parts[2], 'testDate-month': parts[1], 'testDate-year': parts[0] }
+        expect(validateDateParts<BodyType>('testDate', 'Test date', body, options)).toEqual(expected)
       },
     )
   })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -20,12 +20,17 @@ export const escape = (text: string): string => {
   return escapeFilter(text).val
 }
 
-export function convertKeyValuePairToRadioItems<T extends object>(object: T, checkedItem: string): Array<RadioItem> {
+export function convertKeyValuePairToRadioItems<T extends object>(
+  object: T,
+  checkedItem: string,
+  conditionals?: Record<string, unknown>,
+): Array<RadioItem> {
   return Object.entries(object).map(([key, value]) => {
     return {
       value: key,
       text: value,
       checked: checkedItem === key,
+      conditional: conditionals?.[key],
     }
   })
 }

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,5 +1,19 @@
 import * as nunjucks from 'nunjucks'
-import { RadioItem, CheckboxItem, ErrorMessages, HtmlItem, TextItem, SummaryListItem } from '@approved-premises/ui'
+import {
+  RadioItem,
+  CheckboxItem,
+  ErrorMessages,
+  HtmlItem,
+  TextItem,
+  SummaryListItem,
+  type ObjectWithDateParts,
+} from '@approved-premises/ui'
+import {
+  dateAndTimeInputsAreValidDates,
+  dateIsComplete,
+  dateIsTodayOrInTheFuture,
+  dateIsTodayOrInThePast,
+} from './dateUtils'
 
 export const escape = (text: string): string => {
   const escapeFilter = new nunjucks.Environment().getFilter('escape')
@@ -68,4 +82,31 @@ export const summaryListItem = (
 export const isValidEmail = (email: string): boolean => {
   const emailRegex = /^[^\s@]+@[^\s@]+\.gov\.uk$/i
   return emailRegex.test(email)
+}
+
+/**
+ * Validates three-part dates in a form body
+ * @param fieldName The prefix of the date to validate
+ * @param fieldTitle The title of the date to display in error messages
+ * @param body The form body
+ * @param options - to check for future or past dates
+ * @returns an errors object that can be spliced into other form errors
+ * */
+export const validateDateParts = <T>(
+  fieldName: keyof T,
+  fieldTitle: string,
+  body: T,
+  options: { future?: boolean; past?: boolean } = {},
+): Record<keyof T, string> => {
+  let error: string
+
+  if (!dateIsComplete(body as never, fieldName as string)) error = `${fieldTitle} must be entered`
+  if (!error && !dateAndTimeInputsAreValidDates(body as Partial<ObjectWithDateParts<0>>, fieldName as string))
+    error = `${fieldTitle} must be a real date`
+  if (!error && options.future && !dateIsTodayOrInTheFuture(body as never, fieldName as string))
+    error = `${fieldTitle} must be in the future`
+  if (!error && options.past && !dateIsTodayOrInThePast(body as never, fieldName as string))
+    error = `${fieldTitle} must be in the past`
+
+  return (error ? { [fieldName]: error } : {}) as Record<keyof T, string>
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -27,7 +27,7 @@ import {
 import { applicationStatusRadios, applicationStatusDetailOptions } from './assessUtils'
 import { checkYourAnswersSections, getApplicantDetails } from './checkYourAnswersUtils'
 import { DateFormats } from './dateUtils'
-import { dateFieldValues } from './formUtils'
+import { convertKeyValuePairToRadioItems, dateFieldValues } from './formUtils'
 import statusTag from './personUtils'
 import * as TaskListUtils from './taskListUtils'
 import { pagination } from './pagination'
@@ -88,6 +88,7 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addGlobal('dateFieldValues', function sendContextToDateFieldValues(fieldName: string, errors: ErrorMessages) {
     return dateFieldValues(fieldName, this.ctx, errors)
   })
+  njkEnv.addGlobal('dateFieldValuesWithContext', dateFieldValues)
   njkEnv.addGlobal('formatDate', DateFormats.isoDateToUIDate)
 
   njkEnv.addGlobal('checkYourAnswersSections', checkYourAnswersSections)
@@ -96,6 +97,8 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addGlobal('getApplicationTimelineEvents', getApplicationTimelineEvents)
   njkEnv.addGlobal('applicationStatusRadios', applicationStatusRadios)
   njkEnv.addGlobal('applicationStatusDetailOptions', applicationStatusDetailOptions)
+
+  njkEnv.addGlobal('convertKeyValuePairToRadioItems', convertKeyValuePairToRadioItems)
 
   njkEnv.addFilter('removeBlankSummaryListItems', removeBlankSummaryListItems)
   njkEnv.addFilter('formatLines', formatLines)

--- a/server/views/applications/pages/cohort-selection/cohort-selection.njk
+++ b/server/views/applications/pages/cohort-selection/cohort-selection.njk
@@ -21,26 +21,9 @@
 {% block questions %}
     <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
-    {{ formPageRadios(
-        {
-            fieldName: "cohort",
-            items: page.items()
-        },
-        fetchContext()
-    ) }}
-
-    {{
-    formPageTextArea(
-        {
-            fieldName: "notes",
-            label: {
-            text: page.questions.notes.question,
-            classes: "govuk-label--s"
-        }
-        },
-        fetchContext()
-    )
-    }}
+    {% for questionKey, question in page.questions %}
+        {{ formQuestion(questionKey,page.questions,fetchContext()) }}
+    {% endfor %}
 
 {% endblock %}
 

--- a/server/views/applications/pages/cohort-selection/licence-dates-needed.njk
+++ b/server/views/applications/pages/cohort-selection/licence-dates-needed.njk
@@ -1,0 +1,20 @@
+{% extends "../layout.njk" %}
+
+{% block questions %}
+    <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+    {{ formPageRadios(
+        {
+            fieldName: "licenceDatesNeeded",
+            items: page.items()
+        },
+        fetchContext()
+    ) }}
+
+{% endblock %}
+
+{% block button %}
+    {{ govukButton({
+        text: "Continue"
+    }) }}
+{% endblock %}

--- a/server/views/applications/pages/cohort-selection/licence-dates-needed.njk
+++ b/server/views/applications/pages/cohort-selection/licence-dates-needed.njk
@@ -1,15 +1,11 @@
 {% extends "../layout.njk" %}
 
 {% block questions %}
-    <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
-    {{ formPageRadios(
-        {
-            fieldName: "licenceDatesNeeded",
-            items: page.items()
-        },
-        fetchContext()
-    ) }}
+    <h1 class="govuk-heading-l">{{ page.title }}</h1>
+    {% for questionKey, question in page.questions %}
+        {{ formQuestion(questionKey,page.questions,fetchContext()) }}
+    {% endfor %}
 
 {% endblock %}
 

--- a/server/views/applications/pages/cohort-selection/licence-dates.njk
+++ b/server/views/applications/pages/cohort-selection/licence-dates.njk
@@ -1,0 +1,70 @@
+{% extends "../layout.njk" %}
+
+{% block questions %}
+    <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+    {% set hdcExpiryDateHtml %}
+
+        {{ formPageDateInput( {
+            fieldName: "hdcExpiryDate",
+            fieldset: {
+                legend: {
+                    text: page.questions.hdcExpiryDate,
+                    classes: "govuk-fieldset__legend--s"
+                }
+            },
+            items: dateFieldValues('hdcExpiryDate', errors)
+        },
+            fetchContext()) }}
+
+    {% endset %}
+
+    {% if page.questions.licenceStartDate %}
+        {{ formPageDateInput( {
+            fieldName: "licenceStartDate",
+            fieldset: {
+                legend: {
+                    text: page.questions.licenceStartDate,
+                    classes: "govuk-fieldset__legend--s"
+                }
+            },
+            items: dateFieldValues('licenceStartDate', errors)
+        },
+            fetchContext()) }}
+    {% endif %}
+
+    {{ formPageDateInput( {
+        fieldName: "licenceEndDate",
+        fieldset: {
+            legend: {
+                text: page.questions.licenceEndDate,
+                classes: "govuk-fieldset__legend--s"
+            }
+        },
+        items: dateFieldValues('licenceEndDate', errors)
+    },
+        fetchContext()) }}
+
+    {% if  page.questions.hasHdcExpiryDate %}
+        {{ formPageRadios(
+            {
+                fieldName: "hasHdcExpiryDate",
+                fieldset: {
+                legend: {
+                    html:  '<h2 class="govuk-fieldset__heading">' + page.questions.hasHdcExpiryDate + "</h2>",
+                    classes: "govuk-fieldset__legend--m"
+                }
+            },
+                items: page.hdcRadioItems({ yes: { html: hdcExpiryDateHtml} })
+            },
+            fetchContext()
+        ) }}
+    {%  endif %}
+
+{% endblock %}
+
+{% block button %}
+    {{ govukButton({
+        text: "Save and continue"
+    }) }}
+{% endblock %}

--- a/server/views/applications/pages/cohort-selection/licence-dates.njk
+++ b/server/views/applications/pages/cohort-selection/licence-dates.njk
@@ -4,46 +4,14 @@
     <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
     {% set hdcExpiryDateHtml %}
-
-        {{ formPageDateInput( {
-            fieldName: "hdcExpiryDate",
-            fieldset: {
-                legend: {
-                    text: page.questions.hdcExpiryDate,
-                    classes: "govuk-fieldset__legend--s"
-                }
-            },
-            items: dateFieldValues('hdcExpiryDate', errors)
-        },
-            fetchContext()) }}
-
+        {{ formQuestion("hdcExpiryDate", page.questions, fetchContext()) }}
     {% endset %}
 
     {% if page.questions.licenceStartDate %}
-        {{ formPageDateInput( {
-            fieldName: "licenceStartDate",
-            fieldset: {
-                legend: {
-                    text: page.questions.licenceStartDate,
-                    classes: "govuk-fieldset__legend--s"
-                }
-            },
-            items: dateFieldValues('licenceStartDate', errors)
-        },
-            fetchContext()) }}
+        {{ formQuestion("licenceStartDate", page.questions, fetchContext()) }}
     {% endif %}
 
-    {{ formPageDateInput( {
-        fieldName: "licenceEndDate",
-        fieldset: {
-            legend: {
-                text: page.questions.licenceEndDate,
-                classes: "govuk-fieldset__legend--s"
-            }
-        },
-        items: dateFieldValues('licenceEndDate', errors)
-    },
-        fetchContext()) }}
+    {{ formQuestion("licenceEndDate", page.questions, fetchContext()) }}
 
     {% if  page.questions.hasHdcExpiryDate %}
         {{ formPageRadios(
@@ -51,11 +19,11 @@
                 fieldName: "hasHdcExpiryDate",
                 fieldset: {
                 legend: {
-                    html:  '<h2 class="govuk-fieldset__heading">' + page.questions.hasHdcExpiryDate + "</h2>",
+                    html:  '<h2 class="govuk-fieldset__heading">' + page.questions.hasHdcExpiryDate.question + "</h2>",
                     classes: "govuk-fieldset__legend--m"
                 }
             },
-                items: page.hdcRadioItems({ yes: { html: hdcExpiryDateHtml} })
+                items: convertKeyValuePairToRadioItems(page.questions.hasHdcExpiryDate.answers, page.body.hasHdcExpiryDate, { yes: { html: hdcExpiryDateHtml} })
             },
             fetchContext()
         ) }}

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -8,6 +8,7 @@
 {% from "../../components/formFields/form-page-text-area/macro.njk" import formPageTextArea %}
 {% from "../../components/formFields/form-page-input/macro.njk" import formPageInput %}
 {% from "../../components/formFields/form-page-checkboxes/macro.njk" import formPageCheckboxes %}
+{% from "../../components/formFields/form-question/macro.njk" import formQuestion %}
 
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}

--- a/server/views/components/formFields/form-question/macro.njk
+++ b/server/views/components/formFields/form-question/macro.njk
@@ -1,0 +1,54 @@
+{% from "../form-page-radios/macro.njk" import formPageRadios with context %}
+{% from "../form-page-date-input/macro.njk" import formPageDateInput with context %}
+{% from "../form-page-text-area/macro.njk" import formPageTextArea %}
+
+{% macro formQuestion(fieldName, questions, context) %}
+    {% set question = questions[fieldName] %}
+
+    {% if page.questions.length !== 1 or question.question !== page.title %}
+        {% set fieldset = {
+            legend: {
+                html:  '<h2 class="govuk-fieldset__heading">' + question.question + "</h2>",
+                classes: "govuk-fieldset__legend--m"
+            }
+        } %}
+    {% endif %}
+
+    {% if question.dataType === 'radio' %}
+        {{ formPageRadios(
+            {
+                fieldset: fieldset,
+                fieldName: fieldName,
+                items: convertKeyValuePairToRadioItems(question.answers, page.body[qKey])
+            },
+            context
+        ) }}
+    {% endif %}
+
+    {% if question.dataType === 'date' %}
+        {{ formPageDateInput(
+            {
+                fieldName: fieldName,
+                fieldset: fieldset,
+                items: dateFieldValuesWithContext(fieldName, context, context.errors)
+            },
+            context
+        ) }}
+    {% endif %}
+
+    {% if question.dataType === 'textArea' %}
+    {{
+    formPageTextArea(
+        {
+            fieldName: fieldName,
+            label: {
+            text: question.question,
+            classes: "govuk-label--s"
+        }
+        },
+        context
+    )
+    }}
+    {%  endif %}
+
+{% endmacro %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/FM-701
https://dsdmoj.atlassian.net/browse/FM-702

<!-- Is there a JIRA ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Adds the licence dates page and pre-question page for the `isc` cohort.

- Note, these pages are not placed as-per the original designs in the tickets. Because of issues around usability and the difficulties with having a conditional page as the first page in a task, these licence pages have been added to the cohort selection task.
- There is quite a lot logic regarding which dates are relevant for which cohorts, and, as such, there is quite a lot of logic to handle and test validation and removal of orphaned data.
- A validation utility has been added that allows easy validation of multi-part dates in forms
- There seemed like far too much boilerplate code in CAS2 pages, so these two pages have been implemented in what is, hopefully, a more efficient way.
  - the page class inherits from a base class, rather than directly rom the abstract TaskListPage
  - the base class provides default implementation of some methods; in particular, the response method and previous and next.
  - The question definitions have expanded a little to include `dataType` This allows the template to render the correct widget and the response method to render the data correctly.
  - There is the start of a macro that brings together the rendering of most questions. This will need to be expanded to cover more control/widget types. Ultimately, simpler pages may use a generic template rather than there being a specific template for every page.
 

## Screenshots of UI changes

<details>
  <summary>Page for ISC cohort only</summary>
<img width="948" height="502" alt="image" src="https://github.com/user-attachments/assets/c31cd1ab-370f-4537-98f8-090ac349c8b0" />
</details>

<details>
  <summary>Licence date page including HDC expiry (for ATCR cohort only)</summary>
<img width="1085" height="1192" alt="image" src="https://github.com/user-attachments/assets/af7e52bb-e4ad-4a18-900f-cc61fa3b8255" />
</details>

<details>
  <summary>Licence date page showin only end date (for RARR cohort only)</summary>
<img width="798" height="510" alt="image" src="https://github.com/user-attachments/assets/2d510a1b-3b73-47a7-9339-d73b1165d2d3" />
</details>

<details>
  <summary>Tasklist page</summary>
<img width="1269" height="404" alt="image" src="https://github.com/user-attachments/assets/1f11463f-2728-47cd-a304-a81d30a98ba8" />
</details>

<details>
  <summary>Check your answers page</summary>
<img width="1998" height="1100" alt="image" src="https://github.com/user-attachments/assets/15d33098-be58-48ee-8e46-d135684daa52" />
</details>



# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
