### PR TITLE
Fixed back links on new cohort confirm applicant and bail application…

### DIFF
--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -887,20 +887,27 @@ describe('applicationsController', () => {
   })
 
   describe('unauthorisedCourtBailApplication', () => {
-    it('renders the enter unauthorised court bail application template', async () => {
-      ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
-        return { errors: {}, errorSummary: [], userInput: {} }
-      })
+    it.each([
+      ['existing', undefined, paths.applications.applicationOrigin({})],
+      ['new', 'bail', paths.applications.newCohorts.bail.applicationOrigin({})],
+    ])(
+      'renders the unauthorised court bail application template for the %s bail route',
+      async (_name: string, newCohortOrigin: NewCohortApplicationOrigin | undefined, backUrl: string) => {
+        ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
+          return { errors: {}, errorSummary: [], userInput: {} }
+        })
 
-      const requestHandler = applicationsController.unauthorisedCourtBailApplication()
-      await requestHandler(request, response, next)
+        const requestHandler = applicationsController.unauthorisedCourtBailApplication(newCohortOrigin)
+        await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('applications/unauthorised-court-bail-application', {
-        errors: {},
-        errorSummary: [],
-        pageHeading: 'You are unauthorised to make a court bail application',
-      })
-    })
+        expect(response.render).toHaveBeenCalledWith('applications/unauthorised-court-bail-application', {
+          errors: {},
+          errorSummary: [],
+          pageHeading: 'You are unauthorised to make a court bail application',
+          backUrl,
+        })
+      },
+    )
 
     it('renders the form with errors and user input if an error has been sent to the flash', async () => {
       const errorsAndUserInput = createMock<ErrorsAndUserInput>()
@@ -911,6 +918,47 @@ describe('applicationsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('applications/unauthorised-court-bail-application', {
         pageHeading: 'You are unauthorised to make a court bail application',
+        backUrl: paths.applications.applicationOrigin({}),
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        ...errorsAndUserInput.userInput,
+      })
+    })
+  })
+
+  describe('unauthorisedPrisonBailApplication', () => {
+    it.each([
+      ['existing', undefined, paths.applications.applicationOrigin({})],
+      ['new', 'bail', paths.applications.newCohorts.bail.applicationOrigin({})],
+    ])(
+      'renders the unauthorised prison bail application template for the %s bail route',
+      async (_name: string, newCohortOrigin: NewCohortApplicationOrigin | undefined, backUrl: string) => {
+        ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
+          return { errors: {}, errorSummary: [], userInput: {} }
+        })
+
+        const requestHandler = applicationsController.unauthorisedPrisonBailApplication(newCohortOrigin)
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('applications/unauthorised-prison-bail-application', {
+          errors: {},
+          errorSummary: [],
+          pageHeading: 'You are unauthorised to make a prison bail application',
+          backUrl,
+        })
+      },
+    )
+
+    it('renders the form with errors and user input if an error has been sent to the flash', async () => {
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+
+      const requestHandler = applicationsController.unauthorisedPrisonBailApplication()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/unauthorised-prison-bail-application', {
+        pageHeading: 'You are unauthorised to make a prison bail application',
+        backUrl: paths.applications.applicationOrigin({}),
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
         ...errorsAndUserInput.userInput,

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -377,28 +377,40 @@ export default class ApplicationsController {
     }
   }
 
-  unauthorisedCourtBailApplication(): RequestHandler {
+  unauthorisedCourtBailApplication(newCohortOrigin?: NewCohortApplicationOrigin): RequestHandler {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+
+      const backUrl =
+        newCohortOrigin === 'bail'
+          ? paths.applications.newCohorts.bail.applicationOrigin({})
+          : paths.applications.applicationOrigin({})
 
       return res.render('applications/unauthorised-court-bail-application', {
         errors,
         errorSummary,
         ...userInput,
         pageHeading: 'You are unauthorised to make a court bail application',
+        backUrl,
       })
     }
   }
 
-  unauthorisedPrisonBailApplication(): RequestHandler {
+  unauthorisedPrisonBailApplication(newCohortOrigin?: NewCohortApplicationOrigin): RequestHandler {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+
+      const backUrl =
+        newCohortOrigin === 'bail'
+          ? paths.applications.newCohorts.bail.applicationOrigin({})
+          : paths.applications.applicationOrigin({})
 
       return res.render('applications/unauthorised-prison-bail-application', {
         errors,
         errorSummary,
         ...userInput,
         pageHeading: 'You are unauthorised to make a prison bail application',
+        backUrl,
       })
     }
   }

--- a/server/controllers/peopleController.test.ts
+++ b/server/controllers/peopleController.test.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
-import { BailApplicationOrigin } from '@approved-premises/ui'
+import { BailApplicationOrigin, NewCohortApplicationOrigin } from '@approved-premises/ui'
 
 import PeopleController from './peopleController'
 import { errorMessage, errorSummary } from '../utils/validation'
@@ -47,24 +47,31 @@ describe('peopleController', () => {
       })
     })
     describe('when there is a prison number', () => {
-      it('renders the confirm applicant details page', async () => {
-        const requestHandler = peopleController.findByPrisonNumber()
+      it.each([
+        ['existing bail', undefined, paths.applications.searchByPrisonNumber({})],
+        ['new bail', 'bail', paths.applications.newCohorts.bail.searchByPrisonNumber({})],
+      ])(
+        'renders the confirm applicant details page for the %s cohort',
+        async (_name: string, newCohortOrigin: 'bail' | undefined, backUrl: string) => {
+          const requestHandler = peopleController.findByPrisonNumber(newCohortOrigin)
 
-        const person = fullPersonFactory.build({})
+          const person = fullPersonFactory.build({})
 
-        personService.findByPrisonNumber.mockResolvedValue(person)
-        applicationService.createApplication.mockResolvedValue(applicationFactory.build({ id: '123abc' }))
+          personService.findByPrisonNumber.mockResolvedValue(person)
+          applicationService.createApplication.mockResolvedValue(applicationFactory.build({}))
 
-        await requestHandler(request, response, next)
+          await requestHandler(request, response, next)
 
-        expect(response.render).toHaveBeenCalledWith('people/confirm-applicant-details', {
-          pageHeading: `Confirm ${person.name}'s details`,
-          person,
-          date: DateFormats.dateObjtoUIDate(new Date()),
-          dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
-          applicationOrigin,
-        })
-      })
+          expect(response.render).toHaveBeenCalledWith('people/confirm-applicant-details', {
+            pageHeading: `Confirm ${person.name}'s details`,
+            person,
+            date: DateFormats.dateObjtoUIDate(new Date()),
+            dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+            applicationOrigin,
+            backUrl,
+          })
+        },
+      )
 
       describe('when there are errors', () => {
         describe('when there is a 404 error', () => {
@@ -100,7 +107,7 @@ describe('peopleController', () => {
 
         describe('when there is a 403 error', () => {
           it('renders the search-by-prison-number page with a permissions error message', async () => {
-            const requestHandler = peopleController.findByPrisonNumber()
+            const requestHandler = peopleController.findByPrisonNumber('bail')
 
             const err = { data: {}, status: 403 }
 
@@ -124,7 +131,7 @@ describe('peopleController', () => {
                 'You do not have permission to access the prison number SOME_NUMBER, please try another number.',
               ),
             ])
-            expect(response.redirect).toHaveBeenCalledWith(paths.applications.searchByPrisonNumber({}))
+            expect(response.redirect).toHaveBeenCalledWith(paths.applications.newCohorts.bail.searchByPrisonNumber({}))
           })
         })
 
@@ -208,24 +215,34 @@ describe('peopleController', () => {
       })
     })
     describe('when there is a CRN', () => {
-      it('renders the confirm applicant details page', async () => {
-        const requestHandler = peopleController.findByCrn()
+      it.each([
+        ['existing bail', undefined, paths.applications.searchByCrn({})],
+        ['new bail', 'bail', paths.applications.newCohorts.bail.searchByCrn({})],
+        ['other new', 'other', paths.applications.newCohorts.searchByCrn({})],
+      ])(
+        'renders the confirm applicant details page for the %s cohorts',
+        async (_name: string, newCohortOrigin: NewCohortApplicationOrigin | undefined, backUrl: string) => {
+          const requestHandler = peopleController.findByCrn(newCohortOrigin)
 
-        const person = fullPersonFactory.build({})
+          const person = fullPersonFactory.build({})
 
-        personService.findByCrn.mockResolvedValue(person)
-        applicationService.createApplication.mockResolvedValue(applicationFactory.build({ id: '123abc' }))
+          personService.findByCrn.mockResolvedValue(person)
+          applicationService.createApplication.mockResolvedValue(
+            applicationFactory.build({ applicationOrigin: 'courtBail' }),
+          )
 
-        await requestHandler(request, response, next)
+          await requestHandler(request, response, next)
 
-        expect(response.render).toHaveBeenCalledWith('people/confirm-applicant-details', {
-          pageHeading: `Confirm ${person.name}'s details`,
-          person,
-          date: DateFormats.dateObjtoUIDate(new Date()),
-          dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
-          applicationOrigin: 'courtBail',
-        })
-      })
+          expect(response.render).toHaveBeenCalledWith('people/confirm-applicant-details', {
+            pageHeading: `Confirm ${person.name}'s details`,
+            person,
+            date: DateFormats.dateObjtoUIDate(new Date()),
+            dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+            applicationOrigin: 'courtBail',
+            backUrl,
+          })
+        },
+      )
 
       describe('when there are errors', () => {
         describe('when there is a 404 error', () => {
@@ -284,7 +301,7 @@ describe('peopleController', () => {
 
         describe('when the crn is in an invalid format', () => {
           it('renders the search-by-crn page with a incorrect format error message', async () => {
-            const requestHandler = peopleController.findByCrn()
+            const requestHandler = peopleController.findByCrn('bail')
 
             const err = { data: {}, status: 500 }
 
@@ -296,7 +313,7 @@ describe('peopleController', () => {
 
             await requestHandler(request, response, next)
 
-            expect(response.redirect).toHaveBeenCalledWith(paths.applications.searchByCrn({}))
+            expect(response.redirect).toHaveBeenCalledWith(paths.applications.newCohorts.bail.searchByCrn({}))
             expect(flashSpy).toHaveBeenCalledWith('errors', {
               crn: errorMessage('crn', 'Enter a CRN in the correct format'),
             })
@@ -308,7 +325,7 @@ describe('peopleController', () => {
 
         describe('when there is an error of another type', () => {
           it('throws the error', async () => {
-            const requestHandler = peopleController.findByCrn()
+            const requestHandler = peopleController.findByCrn('other')
 
             const err = { data: {}, status: 500 }
 
@@ -326,7 +343,7 @@ describe('peopleController', () => {
             expect(request.flash).toHaveBeenCalledWith('errorSummary', [
               errorSummary('crn', 'Something went wrong. Please try again later.'),
             ])
-            expect(response.redirect).toHaveBeenCalledWith(paths.applications.searchByCrn({}))
+            expect(response.redirect).toHaveBeenCalledWith(paths.applications.newCohorts.searchByCrn({}))
           })
         })
       })

--- a/server/controllers/peopleController.ts
+++ b/server/controllers/peopleController.ts
@@ -1,5 +1,6 @@
 import type { Request, RequestHandler, Response } from 'express'
 
+import { NewCohortApplicationOrigin } from '@approved-premises/ui'
 import { addErrorMessagesToFlash } from '../utils/validation'
 import PersonService from '../services/personService'
 import ApplicationService from '../services/applicationService'
@@ -13,9 +14,14 @@ export default class PeopleController {
     private readonly personService: PersonService,
   ) {}
 
-  findByPrisonNumber(): RequestHandler {
+  findByPrisonNumber(newCohortOrigin?: NewCohortApplicationOrigin): RequestHandler {
     return async (req: Request, res: Response) => {
       const { prisonNumber, applicationOrigin } = req.body
+
+      const backUrl =
+        newCohortOrigin === 'bail'
+          ? paths.applications.newCohorts.bail.searchByPrisonNumber({})
+          : paths.applications.searchByPrisonNumber({})
 
       if (prisonNumber) {
         try {
@@ -27,6 +33,7 @@ export default class PeopleController {
             date: DateFormats.dateObjtoUIDate(new Date()),
             dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
             applicationOrigin,
+            backUrl,
           })
         } catch (err) {
           if (err.status === 404) {
@@ -48,18 +55,28 @@ export default class PeopleController {
             addErrorMessagesToFlash(req, 'prisonNumber', 'Something went wrong. Please try again later.')
           }
 
-          return res.redirect(paths.applications.searchByPrisonNumber({}))
+          return res.redirect(backUrl)
         }
       } else {
         addErrorMessagesToFlash(req, 'prisonNumber', 'Enter a prison number')
-        return res.redirect(paths.applications.searchByPrisonNumber({}))
+        return res.redirect(backUrl)
       }
     }
   }
 
-  findByCrn(): RequestHandler {
+  findByCrn(newCohortOrigin?: NewCohortApplicationOrigin): RequestHandler {
     return async (req: Request, res: Response) => {
       const { crn, applicationOrigin } = req.body
+
+      let backUrl: string
+
+      if (newCohortOrigin === 'bail') {
+        backUrl = paths.applications.newCohorts.bail.searchByCrn({})
+      } else if (newCohortOrigin === 'other') {
+        backUrl = paths.applications.newCohorts.searchByCrn({})
+      } else {
+        backUrl = paths.applications.searchByCrn({})
+      }
 
       if (crn) {
         try {
@@ -71,6 +88,7 @@ export default class PeopleController {
             date: DateFormats.dateObjtoUIDate(new Date()),
             dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
             applicationOrigin,
+            backUrl,
           })
         } catch (err) {
           if (err.status === 404) {
@@ -87,11 +105,11 @@ export default class PeopleController {
             addErrorMessagesToFlash(req, 'crn', 'Something went wrong. Please try again later.')
           }
 
-          return res.redirect(paths.applications.searchByCrn({}))
+          return res.redirect(backUrl)
         }
       } else {
         addErrorMessagesToFlash(req, 'crn', 'Enter a CRN')
-        return res.redirect(paths.applications.searchByCrn({}))
+        return res.redirect(backUrl)
       }
     }
   }

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -77,24 +77,28 @@ export default function applyRoutes(controllers: Controllers, router: Router): R
       },
     )
 
-    post(paths.applications.newCohorts.people.findByCrn.pattern, peopleController.findByCrn(), {
+    post(paths.applications.newCohorts.people.findByCrn.pattern, peopleController.findByCrn('other'), {
       auditEvent: 'FIND_APPLICATION_PERSON_BY_CRN',
       auditBodyParams: ['crn'],
     })
 
-    post(paths.applications.newCohorts.bail.people.findByCrn.pattern, peopleController.findByCrn(), {
+    post(paths.applications.newCohorts.bail.people.findByCrn.pattern, peopleController.findByCrn('bail'), {
       auditEvent: 'FIND_APPLICATION_PERSON_BY_CRN',
       auditBodyParams: ['crn'],
     })
 
-    post(paths.applications.newCohorts.bail.people.findByPrisonNumber.pattern, peopleController.findByPrisonNumber(), {
-      auditEvent: 'FIND_APPLICATION_PERSON_BY_PRISON_NUMBER',
-      auditBodyParams: ['prisonNumber'],
-    })
+    post(
+      paths.applications.newCohorts.bail.people.findByPrisonNumber.pattern,
+      peopleController.findByPrisonNumber('bail'),
+      {
+        auditEvent: 'FIND_APPLICATION_PERSON_BY_PRISON_NUMBER',
+        auditBodyParams: ['prisonNumber'],
+      },
+    )
 
     get(
       paths.applications.newCohorts.bail.unauthorisedCourtBailApplication.pattern,
-      applicationsController.unauthorisedCourtBailApplication(),
+      applicationsController.unauthorisedCourtBailApplication('bail'),
       {
         auditEvent: 'VIEW_APPLICATION_UNAUTHORISED_COURT_BAIL',
       },
@@ -102,7 +106,7 @@ export default function applyRoutes(controllers: Controllers, router: Router): R
 
     get(
       paths.applications.newCohorts.bail.unauthorisedPrisonBailApplication.pattern,
-      applicationsController.unauthorisedPrisonBailApplication(),
+      applicationsController.unauthorisedPrisonBailApplication('bail'),
       {
         auditEvent: 'VIEW_APPLICATION_UNAUTHORISED_PRISON_BAIL',
       },

--- a/server/views/applications/unauthorised-court-bail-application.njk
+++ b/server/views/applications/unauthorised-court-bail-application.njk
@@ -8,7 +8,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.applications.applicationOrigin()
+    href: backUrl
   }) }}
 {% endblock %}
 

--- a/server/views/applications/unauthorised-prison-bail-application.njk
+++ b/server/views/applications/unauthorised-prison-bail-application.njk
@@ -8,7 +8,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.applications.applicationOrigin()
+    href: backUrl
   }) }}
 {% endblock %}
 

--- a/server/views/people/confirm-applicant-details.njk
+++ b/server/views/people/confirm-applicant-details.njk
@@ -12,7 +12,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.applications.applicationOrigin()
+    href: backUrl
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
… errors

# Context

Ticket: https://dsdmoj.atlassian.net/browse/FM-577
Requires the `CAS2_ISR_ENABLED` feature flag

These should be the last changes to the back links for pre-application flow:
- Confirm applicant based on the applicant's CRN
  - Existing bail route
  - New cohort bail route
  - New cohort other routes
- Confirm applicant based on the applicant's prison number
  - Existing bail route
  - New cohort bail route
- Unauthorised prison bail application
  - Existing bail route
  - New cohort bail route
- Unauthorised court bail application
  - Existing bail route
  - New cohort bail route

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
