### PR TITLE
fix failed e2e test

### DIFF
--- a/e2e-tests/steps/aboutThePersonSection.ts
+++ b/e2e-tests/steps/aboutThePersonSection.ts
@@ -116,15 +116,18 @@ export const completeAddressHistoryTask = async (page: Page, name: string) => {
 }
 
 async function completePreviousAddressPage(page: Page, name: string) {
-  const previousAddressPage = await ApplyPage.initialize(
+  const hasFixedAddressPage = await ApplyPage.initialize(
     page,
-    `Did ${name} have a fixed address before being arrested?`,
+    `Did ${name} have a fixed address before entering custody?`,
   )
-  await previousAddressPage.checkRadio('Yes')
-  await previousAddressPage.fillField('Enter their last fixed address', '1 Example Road, Anytown, AB1 2CD')
-  await previousAddressPage.checkRadio('supported accommodation')
+  await hasFixedAddressPage.checkRadio('Yes')
+  await hasFixedAddressPage.clickSave()
 
-  await previousAddressPage.clickSave()
+  const lastFixedAddressPage = await ApplyPage.initialize(page, `Enter ${name}'s last fixed address`)
+  await lastFixedAddressPage.fillField('Address line 1', '1 Example Road')
+  await lastFixedAddressPage.fillField('Town or city', 'Anytown')
+  await lastFixedAddressPage.fillField('Postcode', 'AB1 2CD')
+  await lastFixedAddressPage.clickSave()
 }
 
 export const completePersonalInformationTask = async (page: Page, name: string) => {


### PR DESCRIPTION
# Context

Fixes a broken e2e test caused by https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui/pull/604

- Removed the old test testing the page that was deleted and now testing the new one (the yes radio path)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
