### PR TITLE
FM-687-Change supervision details task visibility based by cohort

### DIFF
--- a/integration_tests/tests/apply/offences-and-concerns/probation-supervision-details/supervised-by-probation.cy.ts
+++ b/integration_tests/tests/apply/offences-and-concerns/probation-supervision-details/supervised-by-probation.cy.ts
@@ -16,11 +16,13 @@
 //    When I continue to the next task / page
 //    Then I see the "task list" page
 
+import { ApplicationOrigin, Cas2Application } from '@approved-premises/api'
 import SupervisedByProbationPage from '../../../../pages/apply/offences-and-concerns/probation-supervision-details/supervisedByProbationPage'
 import CPPDetailsPage from '../../../../pages/apply/offences-and-concerns/probation-supervision-details/cppDetailsPage'
 import TaskListPage from '../../../../pages/apply/taskListPage'
 import Page from '../../../../pages/page'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
+import Chainable = Cypress.Chainable
 
 context('Visit "Offences and concerns" section', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
@@ -79,5 +81,46 @@ context('Visit "Offences and concerns" section', () => {
     page.clickSubmit()
 
     Page.verifyOnPage(TaskListPage, this.application)
+  })
+})
+
+context('Change supervision details task visibility based by cohort', () => {
+  const person = personFactory.build({ name: 'Roger Smith' })
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+    cy.signIn()
+  })
+
+  const buildApplication = (applicationOrigin: ApplicationOrigin): Chainable<Cas2Application> => {
+    return cy.fixture('applicationData.json').then(applicationData => {
+      return applicationFactory.build({ person, data: applicationData, applicationOrigin })
+    })
+  }
+
+  it('shows the task for bail applications', () => {
+    buildApplication('prisonBail').then(application => {
+      cy.task('stubApplicationGet', { application })
+
+      // Given I am on the task list of a bail application
+      const taskListPage = TaskListPage.visit(application)
+
+      // Then I can see the "Add probation supervision details" task
+      taskListPage.shouldShowTaskStatus('add-probation-supervision-details', 'Completed')
+    })
+  })
+
+  it('hides the task for thenew cohort applications', () => {
+    buildApplication('other').then(application => {
+      cy.task('stubApplicationGet', { application })
+
+      // Given I am on the task list of a new cohort application
+      const taskListPage = TaskListPage.visit(application)
+
+      // Then I cannot see the "Add probation supervision details" task
+      taskListPage.shouldNotShowTask('Add probation supervision details')
+    })
   })
 })

--- a/server/form-pages/apply/offences-and-concerns/add-probation-supervision-details/supervisedByProbation.test.ts
+++ b/server/form-pages/apply/offences-and-concerns/add-probation-supervision-details/supervisedByProbation.test.ts
@@ -1,3 +1,4 @@
+import { Cas2Application } from '@approved-premises/api'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import { personFactory, applicationFactory } from '../../../../testutils/factories/index'
 import SupervisedByProbation from './supervisedByProbation'
@@ -43,6 +44,23 @@ describe('Community supervision', () => {
       expect(page.errors()).toEqual({
         probationSupervision: 'Confirm whether the applicant is currently supervised by probation',
       })
+    })
+  })
+
+  describe('isApplicable', () => {
+    it('returns true for court bail applications', () => {
+      const testApplication = { ...application, applicationOrigin: 'courtBail' } as Cas2Application
+      expect(new SupervisedByProbation({}, testApplication).isApplicable()).toBe(true)
+    })
+
+    it('returns true for prison bail applications', () => {
+      const testApplication = { ...application, applicationOrigin: 'prisonBail' } as Cas2Application
+      expect(new SupervisedByProbation({}, testApplication).isApplicable()).toBe(true)
+    })
+
+    it('returns false for new cohort applications', () => {
+      const testApplication = { ...application, applicationOrigin: 'other' } as Cas2Application
+      expect(new SupervisedByProbation({}, testApplication).isApplicable()).toBe(false)
     })
   })
 })

--- a/server/form-pages/apply/offences-and-concerns/add-probation-supervision-details/supervisedByProbation.ts
+++ b/server/form-pages/apply/offences-and-concerns/add-probation-supervision-details/supervisedByProbation.ts
@@ -58,4 +58,8 @@ export default class SupervisedByProbation implements TaskListPage {
     }
     return errors
   }
+
+  isApplicable(): boolean {
+    return ['courtBail', 'prisonBail'].includes(this.application.applicationOrigin)
+  }
 }


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/FM-687

# Changes in this PR

Basically:
 1) Bail continue seeing Supervision Details section as usual
 2) New Cohorts don't see at all that section. The "Who is <name>'s Community Probation Practitioner (CPP)" section has already been moved as part of the referrer PR
 
# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
