### PR TITLE
Couple of fixes for issues identified during UAT

### DIFF
--- a/server/form-pages/apply/health-needs/health-needs/substanceMisuse.ts
+++ b/server/form-pages/apply/health-needs/health-needs/substanceMisuse.ts
@@ -32,7 +32,7 @@ export type SubstanceMisuseBody = {
   ],
 })
 export default class SubstanceMisuse implements TaskListPage {
-  documentTitle = 'Substance misuse details for the person'
+  documentTitle = 'Drug and alcohol use details for the person'
 
   personName = nameOrPlaceholderCopy(this.application.person)
 

--- a/server/form-pages/apply/offences-and-concerns/orders-and-licence-conditions/licenceConditions.ts
+++ b/server/form-pages/apply/offences-and-concerns/orders-and-licence-conditions/licenceConditions.ts
@@ -46,7 +46,7 @@ export default class LicenceConditions implements TaskListPage {
     if (!this.body.hasLicenceConditions)
       errors.hasLicenceConditions = 'Select yes if they have any non-standard licence conditions'
     else if (this.body.hasLicenceConditions === 'yes' && !this.body.notes)
-      errors.notes = 'Provide details of the non-standard licence conditions!'
+      errors.notes = 'Provide details of the non-standard licence conditions'
 
     return errors
   }

--- a/server/views/applications/application-origin.njk
+++ b/server/views/applications/application-origin.njk
@@ -38,7 +38,7 @@
             value: "other",
             text: "A different type of application",
             hint: {
-              text: "Applicant is being released, at risk of bein recalled, or leaving an approved premises with no suitable accommodation."
+              text: "Applicant is being released, at risk of being recalled, or leaving an approved premises with no suitable accommodation."
             }
           }
         ]

--- a/server/views/applications/pages/current-offences/current-offences.njk
+++ b/server/views/applications/pages/current-offences/current-offences.njk
@@ -11,7 +11,7 @@
 
     <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{ page.title }}</h1>
 
-    <p>The CAS2 HDC referral team needs an overview of all current offences to assess risk and make sure people are placed safely.</p>
+    <p>The CAS2 referral team needs an overview of all current offences to assess risk and make sure people are placed safely.</p>
 
     {{ govukButton({
         id: "add-a-current-offence",

--- a/server/views/people/confirm-applicant-details.njk
+++ b/server/views/people/confirm-applicant-details.njk
@@ -49,7 +49,7 @@
                 text: "Confirm and continue"
             }) }}
 
-          <a href="{{ paths.applications.applicationOrigin() }}"> Search for a different applicant </a>
+          <a href="{{ backUrl }}"> Search for a different applicant </a>
         </div>
 
       </form>


### PR DESCRIPTION
# Context

Fixed spelling mistake on the application selection screen: `at risk of bein` -> `at risk of being`

Changed `Search for a different applicant` link on Confirm details page to go back to the CRN/NOMS search page

Changed `The CAS2 HDC referral team...` to `The CAS2 referral team...` on the current offences page

Removed exclamation mark from the end of the error when a user doesn't provide details of licence conditions

Changed the page title of the drug and alcohol use page from `Substance misuse...` to `Drug and alcohol use...`

- [x] E2E tests are passing locally

