### PR TITLE
Fix failing tests

### DIFF
--- a/integration_tests/tests/apply/before_you_apply/solicitor-details/solicitor-details.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/solicitor-details/solicitor-details.cy.ts
@@ -1,14 +1,18 @@
 import { ApplicationOrigin, Cas2CohortDto, Cas2Application } from '@approved-premises/api'
+import { faker } from '@faker-js/faker'
 import { applicationFactory, personFactory, solicitorFactory } from '../../../../../server/testutils/factories'
 import TaskListPage from '../../../../pages/apply/taskListPage'
 import Page from '../../../../pages/page'
 import HasSolicitorPage from '../../../../pages/apply/before_you_apply/solicitor-details/hasSolicitor'
 import Chainable = Cypress.Chainable
 import SolicitorDetailsPage from '../../../../pages/apply/before_you_apply/solicitor-details/solicitorDetails'
-import { isoDateToDateParts } from '../../../../../server/utils/dateUtils'
+import { DateFormats, isoDateToDateParts } from '../../../../../server/utils/dateUtils'
 
 context('Complete "Add solicitor details" task in "Before you apply" section', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
+
+  const licenceEndDate = faker.date.soon({ days: 60 })
+  const licenceStartDate = faker.date.recent({ days: 60, refDate: licenceEndDate })
 
   beforeEach(() => {
     cy.task('reset')
@@ -26,8 +30,8 @@ context('Complete "Add solicitor details" task in "Before you apply" section', (
           'cohort-selection': {
             'cohort-selection': { cohort },
             'licence-dates': {
-              ...isoDateToDateParts('2026-05-03', 'licenceStartDate'),
-              ...isoDateToDateParts('2026-07-12', 'licenceEndDate'),
+              ...isoDateToDateParts(DateFormats.dateObjToIsoDate(licenceStartDate), 'licenceStartDate'),
+              ...isoDateToDateParts(DateFormats.dateObjToIsoDate(licenceEndDate), 'licenceEndDate'),
               hasHdcExpiryDate: 'no',
             },
           },

--- a/server/form-pages/apply/before-you-start/cohort-selection/licence-dates.test.ts
+++ b/server/form-pages/apply/before-you-start/cohort-selection/licence-dates.test.ts
@@ -1,9 +1,10 @@
+import { faker } from '@faker-js/faker'
 import { Cas2CohortDto } from 'server/@types/shared'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import { applicationFactory, personFactory } from '../../../../testutils/factories'
 import LicenceDates, { LicenceDatesBody } from './licence-dates'
 import { getQuestions } from '../../../utils/questions'
-import { isoDateToDateParts } from '../../../../utils/dateUtils'
+import { DateFormats, isoDateToDateParts } from '../../../../utils/dateUtils'
 
 describe('LicenceDates', () => {
   const application = applicationFactory.build({ cohort: 'atcr', person: personFactory.build({ name: 'Roger Smith' }) })
@@ -11,10 +12,18 @@ describe('LicenceDates', () => {
   const page = (cohort: Cas2CohortDto, body = {} as LicenceDatesBody) =>
     new LicenceDates(body, { ...application, cohort })
 
+  const licenceEndDate = faker.date.soon({ days: 60 })
+  const licenceStartDate = faker.date.recent({ days: 60, refDate: licenceEndDate })
+  const hdcExpiryDate = faker.date.soon({ days: 60, refDate: licenceEndDate })
+
+  const licenceStartDateIso = DateFormats.dateObjToIsoDate(licenceStartDate)
+  const licenceEndDateIso = DateFormats.dateObjToIsoDate(licenceEndDate)
+  const hdcExpiryDateIso = DateFormats.dateObjToIsoDate(hdcExpiryDate)
+
   const filledBody: Partial<LicenceDatesBody> = {
-    ...isoDateToDateParts('2026-05-03', 'licenceStartDate'),
-    ...isoDateToDateParts('2026-07-12', 'licenceEndDate'),
-    ...isoDateToDateParts('2026-10-03', 'hdcExpiryDate'),
+    ...isoDateToDateParts(licenceStartDateIso, 'licenceStartDate'),
+    ...isoDateToDateParts(licenceEndDateIso, 'licenceEndDate'),
+    ...isoDateToDateParts(hdcExpiryDateIso, 'hdcExpiryDate'),
     hasHdcExpiryDate: 'yes',
   }
 
@@ -100,9 +109,12 @@ describe('LicenceDates', () => {
 
       expect(testPage.response()).toEqual({
         'Does Roger Smith have an HDC expiry date?': 'Yes',
-        'HDC expiry date': '3 October 2026',
-        "What is Roger Smith's licence end date?": '12 July 2026',
-        "What is Roger Smith's licence start date/conditional release date?": '3 May 2026',
+        'HDC expiry date': DateFormats.isoDateToUIDate(hdcExpiryDateIso, { format: 'medium' }),
+        "What is Roger Smith's licence end date?": DateFormats.isoDateToUIDate(licenceEndDateIso, { format: 'medium' }),
+        "What is Roger Smith's licence start date/conditional release date?": DateFormats.isoDateToUIDate(
+          licenceStartDateIso,
+          { format: 'medium' },
+        ),
       })
     })
   })


### PR DESCRIPTION
# Context

A test had a hardcoded licence date (12 July 2026) but once today's date passed it, the app correctly flagged it as not in the future anymore.

Used faker for a random future date

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
