### PR TITLE
Fix non existing data error

### DIFF
--- a/server/form-pages/apply/health-needs/risks-of-serious-harm-to-others/oasysImport.ts
+++ b/server/form-pages/apply/health-needs/risks-of-serious-harm-to-others/oasysImport.ts
@@ -80,7 +80,7 @@ export default class OasysImport implements TaskListPage {
     let risks: RoshRisksEnvelope
     let taskDataJson
 
-    if (!application.data['risks-of-serious-harm-to-others']) {
+    if (!application.data?.['risks-of-serious-harm-to-others']) {
       try {
         oasys = await dataServices.personService.getOasysRosh(request.user.token, application.person.crn)
         risks = await dataServices.personService.getRoshRisks(request.user.token, application.person.crn)
@@ -98,7 +98,7 @@ export default class OasysImport implements TaskListPage {
   }
 
   private static isRoshApplicationDataImportedFromOASys(application: Application): boolean {
-    const rosh = application.data['risks-of-serious-harm-to-others']
+    const rosh = application.data?.['risks-of-serious-harm-to-others']
     if (rosh?.['oasys-import']?.oasysImportedDate) {
       return true
     }

--- a/server/form-pages/apply/health-needs/risks-of-serious-harm-to-others/summary.ts
+++ b/server/form-pages/apply/health-needs/risks-of-serious-harm-to-others/summary.ts
@@ -223,7 +223,7 @@ export default class Summary implements TaskListPage {
   }
 
   private getRoSHData(application: Application) {
-    return application.data['risks-of-serious-harm-to-others']
+    return application.data?.['risks-of-serious-harm-to-others']
   }
 
   private getRiskDataSource(roshData: unknown): SummaryData | null {


### PR DESCRIPTION
# Context

The app tried to read the risk data on a brand-new (new cohort only) application before any data existed, so it crashed on an empty (null) record. 

# Changes in this PR

Add a check for that data

Just safeguarded the check

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
