### PR TITLE
Finished E2E tests for new cohorts

### DIFF
--- a/e2e-tests/steps/apply.ts
+++ b/e2e-tests/steps/apply.ts
@@ -24,7 +24,12 @@ import {
   completeEqualityAndDiversityTask,
   completePersonalInformationTask,
 } from './aboutThePersonSection'
-import { completeHealthNeedsTask, completeRiskInformationTask } from './risksAndNeedsSection'
+import {
+  completeHealthNeedsTask,
+  completeRiskInformationTask,
+  completeRiskToOthersTask,
+  completeRiskToSelfTask,
+} from './risksAndNeedsSection'
 import { completeAreaInformationTask, completeFundingInformationTask } from './areaAndFundingSection'
 import {
   completeProvideOffencesAndConvictionsDetailsTask,
@@ -144,6 +149,10 @@ export const completeHealthNeedsSection = async (
   applicationOrigin: NewCohortApplicationOrigin,
 ) => {
   await completeHealthNeedsTask(page, name, applicationOrigin)
+  if (applicationOrigin === 'other') {
+    await completeRiskToSelfTask(page, name)
+    await completeRiskToOthersTask(page, name)
+  }
 }
 
 export const completeOffencesAndConcernsSection = async (

--- a/e2e-tests/steps/beforeYouStartSection.ts
+++ b/e2e-tests/steps/beforeYouStartSection.ts
@@ -3,8 +3,8 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
 import { addDays } from 'date-fns'
 import { ApplyPage, TaskListPage } from '../pages/apply'
 import CohortSelectionPage from '../pages/apply/cohortSelectionPage'
-import { cohortLabels } from '../../server/utils/applicationUtils'
 import CohortLicenceDetailsPage from '../pages/apply/cohortLicenceDetailsPage'
+import { cohortLabels } from '../../server/utils/applications/cohortLabels'
 
 export const completeEligibilityTask = async (page: Page, name: string) => {
   const confirmEligibilityPage = await ApplyPage.initialize(page, `Confirm ${name} is eligible for CAS2 for bail`)

--- a/e2e-tests/steps/risksAndNeedsSection.ts
+++ b/e2e-tests/steps/risksAndNeedsSection.ts
@@ -24,6 +24,29 @@ export const completeHealthNeedsTask = async (
   await completeInformationSourcesPage(page)
 }
 
+export const completeRiskToSelfTask = async (page: Page, name: string) => {
+  const taskListPage = new TaskListPage(page)
+  await taskListPage.clickTask('Add risk to self information')
+
+  await reviewOasysImportPage(page, name)
+  await completeVulnerabilityPage(page, name)
+  await completeCurrentAndPreviousRisksPage(page, name)
+  await addARiskToSelfAcct(page, name)
+  await completeAdditionalInformationPage(page, name)
+}
+
+export const completeRiskToOthersTask = async (page: Page, name: string) => {
+  const taskListPage = new TaskListPage(page)
+  await taskListPage.clickTask('Risks of serious harm to others')
+
+  await reviewRoshOasysImportPage(page, name)
+  await completeRoshSummaryPage(page, name)
+  await completeRiskToOthersPage(page, name)
+  await completeRoshRiskManagementArrangementsPage(page, name)
+  await completeCellShareInformationPage(page, name)
+  await completeAdditionalRiskPage(page, name)
+}
+
 async function completeHealthNeedsInformationPage(page: Page, name: string) {
   const healthNeedsInformationPage = await ApplyPage.initialize(
     page,
@@ -241,7 +264,7 @@ async function completeAdditionalConcernsPage(page: Page) {
     'No, they do not have any additional concerns',
   )
 
-  additionalConcernsPage.clickSave()
+  await additionalConcernsPage.clickSave()
 }
 
 async function addAnAcct(page: Page, name: string) {
@@ -276,4 +299,91 @@ async function completeRiskInformationSourcesPage(page: Page) {
   )
   await informationSourcesPage.checkCheckboxes(['Case work'])
   await informationSourcesPage.clickSave()
+}
+
+async function reviewOasysImportPage(page: Page, name: string) {
+  const guidancePage = await ApplyPage.initialize(page, `Import ${name}'s risk to self data from OASys`)
+  await guidancePage.clickContinue()
+}
+
+async function completeVulnerabilityPage(page: Page, name: string) {
+  const vulnerabilityPage = await ApplyPage.initialize(page, `${name}'s vulnerability`)
+
+  await vulnerabilityPage.fillField(
+    `Describe ${name}'s current circumstances, issues and needs related to vulnerability`,
+    'some vulnerability',
+  )
+
+  await vulnerabilityPage.checkCheckboxes(['I confirm this information is relevant and up to date.'])
+  await vulnerabilityPage.clickSave()
+}
+
+async function completeCurrentAndPreviousRisksPage(page: Page, name: string) {
+  const currentAndPreviousRisksPage = await ApplyPage.initialize(page, `${name}'s current and previous risks`)
+
+  await currentAndPreviousRisksPage.fillField(
+    `Describe ${name}'s current and previous issues and needs related to self harm and suicide`,
+    'some needs',
+  )
+
+  await currentAndPreviousRisksPage.checkCheckboxes(['I confirm this information is relevant and up to date.'])
+  await currentAndPreviousRisksPage.clickSave()
+}
+
+async function completeAdditionalInformationPage(page: Page, name: string) {
+  const additionalInformationPage = await ApplyPage.initialize(
+    page,
+    `Is there anything else to include about ${name}'s risk to self?`,
+  )
+  await additionalInformationPage.checkRadio('No')
+  await additionalInformationPage.clickSave()
+}
+
+async function addARiskToSelfAcct(page: Page, name: string) {
+  const acctsPage = await ApplyPage.initialize(page, `${name}'s ACCT notes`)
+  await acctsPage.clickButton('Add an Acct note')
+  await completeRiskToSelfAcctDataPage(page)
+  await acctsPage.clickSave()
+}
+
+async function completeRiskToSelfAcctDataPage(page: Page) {
+  const acctDataPage = await ApplyPage.initialize(page, 'Add an ACCT note')
+  await acctDataPage.fillDateFieldInGroup('When was the ACCT created?', { year: '2022', month: '3', day: '1' })
+  await acctDataPage.checkRadio('Yes')
+  await acctDataPage.fillField('Referring institution', 'HMPPS Sheffield')
+  await acctDataPage.fillField('Details about the ACCT', 'some details')
+  await acctDataPage.clickButton('Save and continue')
+}
+
+async function reviewRoshOasysImportPage(page: Page, name: string) {
+  const guidancePage = await ApplyPage.initialize(page, `Import ${name}'s risk of serious harm (RoSH) data from OASys`)
+  await guidancePage.clickContinue()
+}
+
+async function completeRoshSummaryPage(page: Page, name: string) {
+  const summaryPage = await ApplyPage.initialize(page, `Risk of serious harm (RoSH) summary for ${name}`)
+  await summaryPage.clickSave()
+}
+
+async function completeRiskToOthersPage(page: Page, name: string) {
+  const riskToOthersPage = await ApplyPage.initialize(page, `Risk to others for ${name}`)
+  await riskToOthersPage.clickConfirm()
+}
+
+async function completeRoshRiskManagementArrangementsPage(page: Page, name: string) {
+  const riskManagementArrangementsPage = await ApplyPage.initialize(page, `Risk management arrangements for ${name}`)
+  await riskManagementArrangementsPage.checkCheckboxes(['No, this person does not have risk management arrangements'])
+  await riskManagementArrangementsPage.clickSave()
+}
+
+async function completeCellShareInformationPage(page: Page, name: string) {
+  const cellShareInformationPage = await ApplyPage.initialize(page, `Cell share information for ${name}`)
+  await cellShareInformationPage.checkRadio('No')
+  await cellShareInformationPage.clickSave()
+}
+
+async function completeAdditionalRiskPage(page: Page, name: string) {
+  const additionalRiskPage = await ApplyPage.initialize(page, `Additional risk information for ${name}`)
+  await additionalRiskPage.checkRadio('No')
+  await additionalRiskPage.clickSave()
 }

--- a/e2e-tests/tests/06_new_cohorts_applications.spec.ts
+++ b/e2e-tests/tests/06_new_cohorts_applications.spec.ts
@@ -1,10 +1,13 @@
+import { expect } from '@playwright/test'
 import test from '../test'
 import signIn from '../steps/signIn'
 import {
   completeAboutThePersonSection,
   completeAreaAndFundingSection,
+  completeBailInformationSection,
   completeBeforeYouStartForCustodyApplications,
   completeBeforeYouStartSection,
+  completeCheckAnswersSection,
   completeHealthNeedsSection,
   completeOffencesAndConcernsSection,
   confirmApplicant,
@@ -12,6 +15,7 @@ import {
   enterPrisonerNumber,
   selectBailApplicationOrigin,
   startANewCohortApplication,
+  submitApplication,
 } from '../steps/apply'
 
 test('Create a CAS2 bail application', async ({ page, person, deliusPrisonUser }) => {
@@ -23,7 +27,12 @@ test('Create a CAS2 bail application', async ({ page, person, deliusPrisonUser }
   await completeBeforeYouStartSection(page, person.name)
   await completeAboutThePersonSection(page, person.name, 'bail')
   await completeAreaAndFundingSection(page, person.name, 'bail')
+  await completeOffencesAndConcernsSection(page, person.name, 'bail')
   await completeHealthNeedsSection(page, person.name, 'bail')
+  await completeBailInformationSection(page)
+  await completeCheckAnswersSection(page, person.name)
+  await expect(page.getByText('You have completed 18 of 18 tasks')).toBeVisible()
+  await submitApplication(page)
 })
 
 test('Create a different CAS2 application', async ({ page, person, deliusPrisonUser }) => {
@@ -36,4 +45,7 @@ test('Create a different CAS2 application', async ({ page, person, deliusPrisonU
   await completeAreaAndFundingSection(page, person.name, 'other')
   await completeOffencesAndConcernsSection(page, person.name, 'other')
   await completeHealthNeedsSection(page, person.name, 'other')
+  await completeCheckAnswersSection(page, person.name)
+  await expect(page.getByText('You have completed 16 of 16 tasks')).toBeVisible()
+  await submitApplication(page)
 })

--- a/integration_tests/pages/apply/before_you_apply/cohort-selection/cohortSelection.ts
+++ b/integration_tests/pages/apply/before_you_apply/cohort-selection/cohortSelection.ts
@@ -1,7 +1,7 @@
 import { Cas2Application as Application, FullPerson } from '@approved-premises/api'
 import paths from '../../../../../server/paths/apply'
 import ApplyPage from '../../applyPage'
-import { cohortSelectionAnswers } from '../../../../../server/utils/applications/cohortLabels'
+import { cohortLabels } from '../../../../../server/utils/applications/cohortLabels'
 
 export default class CohortSelectionPage extends ApplyPage {
   constructor(readonly application: Application) {
@@ -25,7 +25,7 @@ export default class CohortSelectionPage extends ApplyPage {
   }
 
   verifyQuestions() {
-    Object.values(cohortSelectionAnswers).forEach(question => {
+    Object.values(cohortLabels).forEach(question => {
       cy.contains(question)
     })
     cy.contains('Provide details (optional)')

--- a/integration_tests/pages/apply/prisonApplicationsPage.ts
+++ b/integration_tests/pages/apply/prisonApplicationsPage.ts
@@ -1,7 +1,7 @@
 import { Cas2ApplicationSummary } from '@approved-premises/api'
 import paths from '../../../server/paths/apply'
-import { cohortLabel } from '../../../server/utils/applicationUtils'
 import Page from '../page'
+import { cohortLabel } from '../../../server/utils/applications/cohortLabels'
 
 export default class PrisonApplicationsPage extends Page {
   constructor() {

--- a/integration_tests/tests/apply/before_you_apply/cohort-selection/cohort-selection.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/cohort-selection/cohort-selection.cy.ts
@@ -2,7 +2,7 @@ import { Cas2CohortDto, Cas2Application } from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 import CohortSelectionPage from '../../../../pages/apply/before_you_apply/cohort-selection/cohortSelection'
-import { cohortSelectionAnswers } from '../../../../../server/utils/applications/cohortLabels'
+import { cohortLabels } from '../../../../../server/utils/applications/cohortLabels'
 import LicenceDatesPage from '../../../../pages/apply/before_you_apply/cohort-selection/licenceDates'
 import LicenceDatesNeededPage from '../../../../pages/apply/before_you_apply/cohort-selection/licenceDatesNeededPage'
 
@@ -29,7 +29,7 @@ context('Complete Cohort selection task in "Before you apply" section', () => {
   it('allows the cohort to be selected', () => {
     cy.task('stubApplicationGet', { application })
     cy.task('stubApplicationUpdate', { application })
-    const newCohort: Cas2CohortDto = faker.helpers.arrayElement(Object.keys(cohortSelectionAnswers)) as Cas2CohortDto
+    const newCohort: Cas2CohortDto = faker.helpers.arrayElement(Object.keys(cohortLabels)) as Cas2CohortDto
 
     // Given I am on the cohort selection page
     const page = CohortSelectionPage.visit(application)

--- a/integration_tests/tests/apply/new_cohorts/task-list.cy.ts
+++ b/integration_tests/tests/apply/new_cohorts/task-list.cy.ts
@@ -2,7 +2,7 @@ import { Cas2Application } from '@approved-premises/api'
 import { applicationFactory, personFactory } from '../../../../server/testutils/factories'
 import TaskListPage from '../../../pages/apply/taskListPage'
 import Page from '../../../pages/page'
-import { cohortLabels } from '../../../../server/utils/applicationUtils'
+import { cohortLabels } from '../../../../server/utils/applications/cohortLabels'
 
 context('Task list page', () => {
   const person = personFactory.build({ name: 'Roger Smith' })

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -1,4 +1,4 @@
-import { cohortSelectionAnswers } from '../../utils/applications/cohortLabels'
+import { cohortLabels } from '../../utils/applications/cohortLabels'
 
 export type Question = { question: string; answers?: Record<string, string>; hint?: string; dataType?: string }
 type QuestionsNode = { [property: string]: Question | QuestionsNode }
@@ -85,7 +85,7 @@ export function getQuestions(
       'cohort-selection': {
         cohort: {
           question: `Why does ${name} need CAS2 accommodation?`,
-          answers: cohortSelectionAnswers,
+          answers: cohortLabels,
           dataType: 'radio',
         },
         notes: {

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -4,13 +4,13 @@ import { ApplicationOrigin, Cas2Application as Application, Cas2CohortDto } from
 import { DateFormats } from '../../utils/dateUtils'
 import { fullPersonFactory, restrictedPersonFactory } from './person'
 import cas2v2UserFactory from './cas2v2User'
-import { cohortSelectionAnswers } from '../../utils/applications/cohortLabels'
+import { cohortLabels } from '../../utils/applications/cohortLabels'
 
 class ApplicationFactory extends Factory<Application> {
   newCohort(cohort?: Cas2CohortDto) {
     return this.params({
       applicationOrigin: 'other',
-      cohort: cohort || (faker.helpers.arrayElement(Object.keys(cohortSelectionAnswers)) as Cas2CohortDto),
+      cohort: cohort || (faker.helpers.arrayElement(Object.keys(cohortLabels)) as Cas2CohortDto),
       data: {
         'cohort-selection': {
           'cohort-selection': { cohort },

--- a/server/testutils/factories/applicationSummary.ts
+++ b/server/testutils/factories/applicationSummary.ts
@@ -3,8 +3,8 @@ import { faker } from '@faker-js/faker'
 import { Cas2CohortDto, Cas2ApplicationSummary } from '@approved-premises/api'
 
 import { DateFormats } from '../../utils/dateUtils'
-import { cohortLabels } from '../../utils/applicationUtils'
 import latestStatusUpdateFactory from './latestStatusUpdate'
+import { cohortLabels } from '../../utils/applications/cohortLabels'
 
 export default Factory.define<Cas2ApplicationSummary>(() => ({
   id: faker.string.uuid(),

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -50,7 +50,7 @@ describe('inProgressApplicationTableRows', () => {
           text: '10 November 2022',
         },
         {
-          text: 'Alternative to custodial recall',
+          text: 'Alternative to custodial recall (ATCR)',
         },
         {
           html: `<a id="cancel-${applicationA.id}" href=/applications/${applicationA.id}/cancel>Cancel</a>`,
@@ -73,7 +73,7 @@ describe('inProgressApplicationTableRows', () => {
           text: '11 November 2022',
         },
         {
-          text: 'Intensive supervision courts',
+          text: 'Intensive supervision courts (ISC)',
         },
         {
           html: `<a id="cancel-${applicationB.id}" href=/applications/${applicationB.id}/cancel>Cancel</a>`,

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,9 +1,4 @@
-import type {
-  Cas2CohortDto,
-  Cas2SubmittedApplicationSummary,
-  Cas2ApplicationSummary,
-  Cas2Application,
-} from '@approved-premises/api'
+import type { Cas2SubmittedApplicationSummary, Cas2ApplicationSummary, Cas2Application } from '@approved-premises/api'
 import type { QuestionAndAnswer, SummaryListItem, TableRow } from '@approved-premises/ui'
 import { UnspentConvictionsUI } from '../form-pages/apply/offences-and-concerns/previous-unspent-convictions/unspentConvictions'
 import applyPaths from '../paths/apply'
@@ -11,20 +6,7 @@ import assessPaths from '../paths/assess'
 import { DateFormats } from './dateUtils'
 import { formatLines } from './viewUtils'
 import { summaryListItem } from './formUtils'
-
-export const cohortLabels: Record<Cas2CohortDto, string> = {
-  hdc: 'Home Detention Curfew',
-  prisonBail: 'Prison Bail',
-  courtBail: 'Court Bail',
-  atcr: 'Alternative to custodial recall',
-  hcrd: 'Homeless at conditional release date',
-  hefr: 'Homeless at end of fixed‑term recall',
-  isc: 'Intensive supervision courts',
-  rarr: 'Risk Assessed Recall Review',
-  from_ap: 'Move on from Approved Premises',
-}
-
-export const cohortLabel = (cohort?: Cas2CohortDto): string => (cohort ? (cohortLabels[cohort] ?? cohort) : '')
+import { cohortLabel } from './applications/cohortLabels'
 
 export const inProgressApplicationTableRows = (applications: Array<Cas2ApplicationSummary>): Array<TableRow> => {
   return applications.map(application => {

--- a/server/utils/applications/cohortLabels.ts
+++ b/server/utils/applications/cohortLabels.ts
@@ -2,13 +2,18 @@ import { Cas2CohortDto } from '@approved-premises/api'
 
 export type NonBailCohort = Exclude<Cas2CohortDto, 'hdc' | 'prisonBail' | 'courtBail'>
 
-export const cohortSelectionAnswers: Record<NonBailCohort, string> = {
+export const cohortLabels: Record<Cas2CohortDto, string> = {
+  hdc: 'Home Detention Curfew',
+  prisonBail: 'Prison Bail',
+  courtBail: 'Court Bail',
   atcr: 'Alternative to custodial recall (ATCR)',
   hcrd: 'Homeless at conditional release date (HCRD)',
-  hefr: 'Homeless at end of fixed term recall',
+  hefr: 'Homeless at end of fixed-term recall',
   isc: 'Intensive supervision courts (ISC)',
   rarr: 'Risk Assessed Recall Review (RARR)',
   from_ap: 'Referral from Approved Premises',
 }
+
+export const cohortLabel = (cohort?: Cas2CohortDto): string => (cohort ? (cohortLabels[cohort] ?? cohort) : '')
 
 export const custodialCohorts: Array<Cas2CohortDto> = ['rarr', 'hcrd', 'hefr', 'hdc', 'prisonBail', 'courtBail']

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -328,6 +328,7 @@ describe('utils', () => {
           errors: {},
           referer: 'some-validated-referer',
           title: 'Apply for CAS2 for Bail',
+          cohortLabel: 'Prison Bail',
         })
       })
 

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -21,7 +21,7 @@ import paths from '../../paths/apply'
 import { DateFormats } from '../dateUtils'
 import { fetchErrorsAndUserInput } from '../validation'
 import { TaskListService } from '../../services'
-import { cohortSelectionAnswers, NonBailCohort } from './cohortLabels'
+import { cohortLabels, NonBailCohort } from './cohortLabels'
 
 export const journeyPages = (_journeyType: JourneyType): FormPages => {
   return Apply.pages
@@ -125,7 +125,7 @@ export const showMissingRequiredTasksOrTaskList = (req: Request, res: Response, 
 
   return res.render('applications/taskList', {
     application,
-    cohortLabel: cohortSelectionAnswers[application.cohort as NonBailCohort],
+    cohortLabel: cohortLabels[application.cohort as NonBailCohort],
     title: application.applicationOrigin === 'other' ? 'Apply for CAS2' : 'Apply for CAS2 for Bail',
     taskList,
     errors,


### PR DESCRIPTION
# Context

This PR contains work that's fallen out of [FM-691](https://dsdmoj.atlassian.net/browse/FM-691)

I ran through the Bail and non-Bail flows to check the bits that haven't changed still work as expected, and extended the new route E2E tests to cover Bail and Other Cohorts via the new dashboard tile.

This work has ended up covering [FM-879](https://dsdmoj.atlassian.net/browse/FM-879), [FM-880](https://dsdmoj.atlassian.net/browse/FM-880), and [FM-881](https://dsdmoj.atlassian.net/browse/FM-881) too

E2E tests now cover the whole application process for the ISC cohort, though this can be changed to use a random new cohort with a little extra work.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

## Post merge

Once we've merged it will be auto-deployed to the dev environment.


[FM-691]: https://dsdmoj.atlassian.net/browse/FM-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FM-879]: https://dsdmoj.atlassian.net/browse/FM-879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FM-880]: https://dsdmoj.atlassian.net/browse/FM-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FM-881]: https://dsdmoj.atlassian.net/browse/FM-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ