### PR TITLE
Add current offences to the document

### DIFF
--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -920,8 +920,16 @@ describe('getPage', () => {
         page2: { question2: { question: 'Another question' } },
       },
     } as unknown as Questions
-    const applicationPageKeys = ['page1', 'page2', 'oldPageKey', 'acct', 'unspent-convictions']
-    const expected = ['page1', 'page2', 'acct', 'unspent-convictions']
+    const applicationPageKeys = [
+      'page1',
+      'page2',
+      'oldPageKey',
+      'acct',
+      'alleged-offences',
+      'current-offences',
+      'unspent-convictions',
+    ]
+    const expected = ['page1', 'page2', 'acct', 'alleged-offences', 'current-offences', 'unspent-convictions']
     expect(removeAnyOldPageKeys(questions, 'task1', applicationPageKeys)).toEqual(expected)
   })
 })

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -303,7 +303,9 @@ export const getApplicantDetails = (application: Application | Cas2SubmittedAppl
 export const removeAnyOldPageKeys = (questions: any, task: string, applicationPageKeys: string[]): string[] => {
   const latestPageKeys = Object.keys(questions[task])
   const matchedKeys = applicationPageKeys.filter(
-    key => latestPageKeys.includes(key) || ['acct', 'alleged-offences', 'unspent-convictions'].includes(key),
+    key =>
+      latestPageKeys.includes(key) ||
+      ['acct', 'alleged-offences', 'current-offences', 'unspent-convictions'].includes(key),
   )
   return matchedKeys
 }


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/FM-894

# Changes in this PR

-  Adds current-offences to the Check Your Answers page allowlist so the page that renders the offences stops being filtered out. Sends also the current offences as part of the `POST /cas2/submissions` request

## Screenshots of UI changes (Check Your Answers page)

### Before

<img width="369" height="182" alt="Screenshot 2026-07-15 at 14 26 08" src="https://github.com/user-attachments/assets/bd752ab3-d453-4054-852f-166919434730" />

### After

<img width="452" height="299" alt="Screenshot 2026-07-15 at 14 20 05" src="https://github.com/user-attachments/assets/b1a50327-dc3e-4887-b756-2f93b8ca6302" />



# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
