### PR TITLE
Ensure HDC and Bail do not appear on the cohort selection page

### DIFF
--- a/integration_tests/pages/apply/before_you_apply/cohort-selection/cohortSelection.ts
+++ b/integration_tests/pages/apply/before_you_apply/cohort-selection/cohortSelection.ts
@@ -1,7 +1,7 @@
 import { Cas2Application as Application, FullPerson } from '@approved-premises/api'
 import paths from '../../../../../server/paths/apply'
 import ApplyPage from '../../applyPage'
-import { cohortLabels } from '../../../../../server/utils/applications/cohortLabels'
+import { newCohortLabels } from '../../../../../server/utils/applications/cohortLabels'
 
 export default class CohortSelectionPage extends ApplyPage {
   constructor(readonly application: Application) {
@@ -25,7 +25,7 @@ export default class CohortSelectionPage extends ApplyPage {
   }
 
   verifyQuestions() {
-    Object.values(cohortLabels).forEach(question => {
+    Object.values(newCohortLabels).forEach(question => {
       cy.contains(question)
     })
     cy.contains('Provide details (optional)')

--- a/integration_tests/tests/apply/before_you_apply/cohort-selection/cohort-selection.cy.ts
+++ b/integration_tests/tests/apply/before_you_apply/cohort-selection/cohort-selection.cy.ts
@@ -2,7 +2,7 @@ import { Cas2CohortDto, Cas2Application } from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
 import { personFactory, applicationFactory } from '../../../../../server/testutils/factories/index'
 import CohortSelectionPage from '../../../../pages/apply/before_you_apply/cohort-selection/cohortSelection'
-import { cohortLabels } from '../../../../../server/utils/applications/cohortLabels'
+import { newCohortLabels, NonBailCohort } from '../../../../../server/utils/applications/cohortLabels'
 import LicenceDatesPage from '../../../../pages/apply/before_you_apply/cohort-selection/licenceDates'
 import LicenceDatesNeededPage from '../../../../pages/apply/before_you_apply/cohort-selection/licenceDatesNeededPage'
 
@@ -29,7 +29,7 @@ context('Complete Cohort selection task in "Before you apply" section', () => {
   it('allows the cohort to be selected', () => {
     cy.task('stubApplicationGet', { application })
     cy.task('stubApplicationUpdate', { application })
-    const newCohort: Cas2CohortDto = faker.helpers.arrayElement(Object.keys(cohortLabels)) as Cas2CohortDto
+    const newCohort: NonBailCohort = faker.helpers.arrayElement(Object.keys(newCohortLabels)) as NonBailCohort
 
     // Given I am on the cohort selection page
     const page = CohortSelectionPage.visit(application)

--- a/server/form-pages/utils/questions.ts
+++ b/server/form-pages/utils/questions.ts
@@ -1,4 +1,4 @@
-import { cohortLabels } from '../../utils/applications/cohortLabels'
+import { newCohortLabels } from '../../utils/applications/cohortLabels'
 
 export type Question = { question: string; answers?: Record<string, string>; hint?: string; dataType?: string }
 type QuestionsNode = { [property: string]: Question | QuestionsNode }
@@ -85,7 +85,7 @@ export function getQuestions(
       'cohort-selection': {
         cohort: {
           question: `Why does ${name} need CAS2 accommodation?`,
-          answers: cohortLabels,
+          answers: newCohortLabels,
           dataType: 'radio',
         },
         notes: {

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -4,13 +4,13 @@ import { ApplicationOrigin, Cas2Application as Application, Cas2CohortDto } from
 import { DateFormats } from '../../utils/dateUtils'
 import { fullPersonFactory, restrictedPersonFactory } from './person'
 import cas2v2UserFactory from './cas2v2User'
-import { cohortLabels } from '../../utils/applications/cohortLabels'
+import { newCohortLabels } from '../../utils/applications/cohortLabels'
 
 class ApplicationFactory extends Factory<Application> {
   newCohort(cohort?: Cas2CohortDto) {
     return this.params({
       applicationOrigin: 'other',
-      cohort: cohort || (faker.helpers.arrayElement(Object.keys(cohortLabels)) as Cas2CohortDto),
+      cohort: cohort || (faker.helpers.arrayElement(Object.keys(newCohortLabels)) as Cas2CohortDto),
       data: {
         'cohort-selection': {
           'cohort-selection': { cohort },

--- a/server/utils/applications/cohortLabels.ts
+++ b/server/utils/applications/cohortLabels.ts
@@ -2,16 +2,20 @@ import { Cas2CohortDto } from '@approved-premises/api'
 
 export type NonBailCohort = Exclude<Cas2CohortDto, 'hdc' | 'prisonBail' | 'courtBail'>
 
-export const cohortLabels: Record<Cas2CohortDto, string> = {
-  hdc: 'Home Detention Curfew',
-  prisonBail: 'Prison Bail',
-  courtBail: 'Court Bail',
+export const newCohortLabels: Record<NonBailCohort, string> = {
   atcr: 'Alternative to custodial recall (ATCR)',
   hcrd: 'Homeless at conditional release date (HCRD)',
   hefr: 'Homeless at end of fixed-term recall',
   isc: 'Intensive supervision courts (ISC)',
   rarr: 'Risk Assessed Recall Review (RARR)',
   from_ap: 'Referral from Approved Premises',
+}
+
+export const cohortLabels: Record<Cas2CohortDto, string> = {
+  hdc: 'Home Detention Curfew',
+  prisonBail: 'Prison Bail',
+  courtBail: 'Court Bail',
+  ...newCohortLabels,
 }
 
 export const cohortLabel = (cohort?: Cas2CohortDto): string => (cohort ? (cohortLabels[cohort] ?? cohort) : '')

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -10,6 +10,7 @@ import {
 import type {
   Cas2Application as Application,
   Cas2Application,
+  Cas2CohortDto,
   Cas2SubmittedApplication,
   Cas2TimelineEvent,
 } from '@approved-premises/api'
@@ -21,7 +22,7 @@ import paths from '../../paths/apply'
 import { DateFormats } from '../dateUtils'
 import { fetchErrorsAndUserInput } from '../validation'
 import { TaskListService } from '../../services'
-import { cohortLabels, NonBailCohort } from './cohortLabels'
+import { cohortLabels } from './cohortLabels'
 
 export const journeyPages = (_journeyType: JourneyType): FormPages => {
   return Apply.pages
@@ -125,7 +126,7 @@ export const showMissingRequiredTasksOrTaskList = (req: Request, res: Response, 
 
   return res.render('applications/taskList', {
     application,
-    cohortLabel: cohortLabels[application.cohort as NonBailCohort],
+    cohortLabel: cohortLabels[application.cohort as Cas2CohortDto],
     title: application.applicationOrigin === 'other' ? 'Apply for CAS2' : 'Apply for CAS2 for Bail',
     taskList,
     errors,


### PR DESCRIPTION
# Context

Ticket: [FM-897](https://dsdmoj.atlassian.net/browse/FM-897)

Fixed my previous mistake when trying to make the display names consistent

E2E tests have been run and pass locally

# Changes in this PR

## Screenshots of UI changes

### Before
<img width="1800" height="1806" alt="image" src="https://github.com/user-attachments/assets/c411687d-70f4-4f5e-80cb-408824989730" />

### After
<img width="1722" height="1397" alt="image" src="https://github.com/user-attachments/assets/c142c47e-0ef5-4e25-883b-87e52faf4173" />

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.


[FM-897]: https://dsdmoj.atlassian.net/browse/FM-897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ