### PR TITLE
Prevent document from showing non-applicable tasks

### DIFF
--- a/integration_tests/pages/apply/check_your_answers/check-your-answers/checkYourAnswersPage.ts
+++ b/integration_tests/pages/apply/check_your_answers/check-your-answers/checkYourAnswersPage.ts
@@ -4,7 +4,12 @@ import { FullPerson } from '../../../../../server/@types/shared/models/FullPerso
 import ApplyPage from '../../applyPage'
 import { nameOrPlaceholderCopy, stringToKebabCase, htmlToPlainText } from '../../../../../server/utils/utils'
 import { getQuestions } from '../../../../../server/form-pages/utils/questions'
-import { getPage, getSections, hasResponseMethod } from '../../../../../server/utils/checkYourAnswersUtils'
+import {
+  getPage,
+  getSections,
+  hasResponseMethod,
+  taskAppliesToApplication,
+} from '../../../../../server/utils/checkYourAnswersUtils'
 import { getCustodyLocation } from '../../../../../server/utils/getApplicationSummaryData'
 
 export default class CheckYourAnswersPage extends ApplyPage {
@@ -29,6 +34,11 @@ export default class CheckYourAnswersPage extends ApplyPage {
   shouldShowAnswersForTask(task: UiTask): void {
     this.shouldShowCheckYourAnswersTitle(task.id, task.title)
     this.shouldShowQuestionsAndAnswers(task.id)
+  }
+
+  shouldNotShowTask(task: UiTask): void {
+    cy.get(`[data-cy-check-your-answers-section="${task.id}"]`).should('not.exist')
+    cy.get(`a[href="#${stringToKebabCase(task.title)}"]`).should('not.exist')
   }
 
   shouldShowCheckYourAnswersTitle(taskName: string, taskTitle: string) {
@@ -98,9 +108,11 @@ export default class CheckYourAnswersPage extends ApplyPage {
     const sections = getSections()
 
     sections.forEach(section => {
-      section.tasks.forEach(task => {
-        cy.get(`a[href="#${stringToKebabCase(task.title)}"]`)
-      })
+      section.tasks
+        .filter(task => taskAppliesToApplication(task, this.application))
+        .forEach(task => {
+          cy.get(`a[href="#${stringToKebabCase(task.title)}"]`)
+        })
     })
   }
 }

--- a/integration_tests/tests/apply/check_your_answers/check_your_answers.cy.ts
+++ b/integration_tests/tests/apply/check_your_answers/check_your_answers.cy.ts
@@ -7,7 +7,7 @@ import Page from '../../../pages/page'
 import CheckYourAnswersPage from '../../../pages/apply/check_your_answers/check-your-answers/checkYourAnswersPage'
 import { personFactory, applicationFactory } from '../../../../server/testutils/factories/index'
 import TaskListPage from '../../../pages/apply/taskListPage'
-import { getSections } from '../../../../server/utils/checkYourAnswersUtils'
+import { getSections, taskAppliesToApplication } from '../../../../server/utils/checkYourAnswersUtils'
 
 context('Check your answers page', () => {
   const person = personFactory.build({ name: 'Roger Smith' })
@@ -57,10 +57,15 @@ context('Check your answers page', () => {
     page.shouldShowSideNavBar()
     page.shouldNotShowAnswersWithoutQuestions()
 
+    //  And tasks that belonging to another application origin are not shown at all
     const sections = getSections()
     sections.forEach(section => {
       section.tasks.forEach(task => {
-        page.shouldShowAnswersForTask(task)
+        if (taskAppliesToApplication(task, this.application)) {
+          page.shouldShowAnswersForTask(task)
+        } else {
+          page.shouldNotShowTask(task)
+        }
       })
     })
   })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -3,6 +3,7 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { Cas2Application as Application, Cas2ApplicationSummary } from '@approved-premises/api'
 import {
   NewCohortApplicationOrigin,
+  ApplicationDocument,
   BailApplicationOrigin,
   ErrorsAndUserInput,
   GroupedApplications,
@@ -28,7 +29,7 @@ import {
 import ApplicationsController from './applicationsController'
 import { PersonService, ApplicationService, SubmittedApplicationService } from '../../services'
 import paths from '../../paths/apply'
-import { buildDocument } from '../../utils/applications/documentUtils'
+import { buildDocument, filterDocumentToApplicableTasks } from '../../utils/applications/documentUtils'
 import config from '../../config'
 import { showMissingRequiredTasksOrTaskList, generateSuccessMessage } from '../../utils/applications/utils'
 import TaskListService from '../../services/taskListService'
@@ -173,17 +174,22 @@ describe('applicationsController', () => {
 
   describe('show', () => {
     describe('when application is submitted', () => {
-      it('renders the submitted view', async () => {
+      it('renders the submitted view, filtering the document to applicable tasks', async () => {
         const submittedApplication = applicationFactory.build({ submittedAt: new Date().toISOString() })
         applicationService.findApplication.mockResolvedValue(submittedApplication)
+
+        const filteredDocument: ApplicationDocument = { sections: [] }
+        ;(filterDocumentToApplicableTasks as jest.Mock).mockReturnValue(filteredDocument)
 
         const requestHandler = applicationsController.show()
         await requestHandler(request, response, next)
 
+        expect(filterDocumentToApplicableTasks).toHaveBeenCalledWith(submittedApplication)
+
         const expectedSummary = getApplicationSummaryData('referrerSubmission', submittedApplication)
 
         expect(response.render).toHaveBeenCalledWith('applications/show', {
-          application: submittedApplication,
+          application: { ...submittedApplication, document: filteredDocument },
           summary: expectedSummary,
         })
       })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -15,7 +15,7 @@ import paths from '../../paths/apply'
 import { getPage } from '../../utils/applications/getPage'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
 import { nameOrPlaceholderCopy } from '../../utils/utils'
-import { buildDocument } from '../../utils/applications/documentUtils'
+import { buildDocument, filterDocumentToApplicableTasks } from '../../utils/applications/documentUtils'
 import { hasRole } from '../../utils/userUtils'
 import TaskListService from '../../services/taskListService'
 import { getApplicationSummaryData } from '../../utils/getApplicationSummaryData'
@@ -75,6 +75,7 @@ export default class ApplicationsController {
       const application = await this.applicationService.findApplication(req.user.token, req.params.id)
 
       if (application.submittedAt) {
+        application.document = filterDocumentToApplicableTasks(application)
         const summary = getApplicationSummaryData('referrerSubmission', application)
         return res.render('applications/show', { application, summary })
       }

--- a/server/utils/applications/documentUtils.test.ts
+++ b/server/utils/applications/documentUtils.test.ts
@@ -1,59 +1,67 @@
-import { buildDocument } from './documentUtils'
+import { buildDocument, filterDocumentToApplicableTasks } from './documentUtils'
 import { applicationFactory } from '../../testutils/factories'
-import { getSections, getTaskAnswersAsSummaryListItems } from '../checkYourAnswersUtils'
+import { getSections, getTaskAnswersAsSummaryListItems, taskAppliesToApplication } from '../checkYourAnswersUtils'
 
 jest.mock('../checkYourAnswersUtils')
 
-const mockQuestionData = {
-  question: 'Question',
-  answer: 'Answer',
-}
+const questionAndAnswer = { question: 'Question', answer: 'Answer' }
 
-const mockSectionData = {
-  title: 'Section',
-  name: 'section',
-  tasks: [{ title: 'Task' }],
-}
+const applicableTask = { title: 'Applicable task' }
+const notApplicableTask = { title: 'Not applicable task' }
 
 describe('documentUtils', () => {
-  describe('buildDocument', () => {
-    it('returns a correctly structured application document', () => {
-      ;(getTaskAnswersAsSummaryListItems as jest.Mock).mockReturnValue([mockQuestionData])
-      ;(getSections as jest.Mock).mockReturnValue([mockSectionData])
+  const application = applicationFactory.build()
 
-      const application = applicationFactory.build({
-        data: {
-          'equality-and-diversity-monitoring': {
-            'will-answer-equality-questions': {
-              willAnswer: 'yes',
-            },
-            disability: {
-              hasDisability: 'no',
-            },
+  beforeEach(() => {
+    ;(getTaskAnswersAsSummaryListItems as jest.Mock).mockReturnValue([questionAndAnswer])
+    ;(getSections as jest.Mock).mockReturnValue([
+      { title: 'Mixed section', name: 'mixed-section', tasks: [applicableTask, notApplicableTask] },
+      { title: 'Not applicable section', name: 'not-applicable-section', tasks: [notApplicableTask] },
+    ])
+    ;(taskAppliesToApplication as jest.Mock).mockImplementation(task => task === applicableTask)
+  })
+
+  describe('buildDocument', () => {
+    it('includes only the tasks that apply to the application', () => {
+      expect(buildDocument(application)).toEqual({
+        sections: [
+          {
+            title: 'Mixed section',
+            tasks: [{ title: 'Applicable task', questionsAndAnswers: [questionAndAnswer] }],
           },
+        ],
+      })
+    })
+  })
+
+  describe('filterDocumentToApplicableTasks', () => {
+    it('removes tasks that do not apply to the application', () => {
+      const submittedApplication = applicationFactory.build({
+        document: {
+          sections: [
+            {
+              title: 'Mixed section',
+              tasks: [
+                { title: 'Applicable task', questionsAndAnswers: [questionAndAnswer] },
+                { title: 'Not applicable task', questionsAndAnswers: [] },
+              ],
+            },
+            {
+              title: 'Not applicable section',
+              tasks: [{ title: 'Not applicable task', questionsAndAnswers: [] }],
+            },
+          ],
         },
       })
 
-      const expected = {
+      expect(filterDocumentToApplicableTasks(submittedApplication)).toEqual({
         sections: [
           {
-            title: 'Section',
-            tasks: [
-              {
-                title: 'Task',
-                questionsAndAnswers: [
-                  {
-                    question: 'Question',
-                    answer: 'Answer',
-                  },
-                ],
-              },
-            ],
+            title: 'Mixed section',
+            tasks: [{ title: 'Applicable task', questionsAndAnswers: [questionAndAnswer] }],
           },
         ],
-      }
-
-      expect(buildDocument(application)).toEqual(expected)
+      })
     })
   })
 })

--- a/server/utils/applications/documentUtils.ts
+++ b/server/utils/applications/documentUtils.ts
@@ -1,23 +1,45 @@
 import { ApplicationDocument, QuestionAndAnswer } from '@approved-premises/ui'
-import { getSections, getTaskAnswersAsSummaryListItems } from '../checkYourAnswersUtils'
+import { getSections, getTaskAnswersAsSummaryListItems, taskAppliesToApplication } from '../checkYourAnswersUtils'
 import { Cas2Application as Application } from '../../@types/shared'
 
 export const buildDocument = (application: Application): ApplicationDocument => {
   return {
-    sections: getSections().map(section => {
-      return {
-        title: section.title,
-        tasks: section.tasks.map(task => {
-          return {
-            title: task.title,
-            questionsAndAnswers: getTaskAnswersAsSummaryListItems(
-              task.id,
-              application,
-              'document',
-            ) as Array<QuestionAndAnswer>,
-          }
-        }),
-      }
-    }),
+    sections: getSections()
+      .map(section => {
+        return {
+          title: section.title,
+          tasks: section.tasks
+            .filter(task => taskAppliesToApplication(task, application))
+            .map(task => {
+              return {
+                title: task.title,
+                questionsAndAnswers: getTaskAnswersAsSummaryListItems(
+                  task.id,
+                  application,
+                  'document',
+                ) as Array<QuestionAndAnswer>,
+              }
+            }),
+        }
+      })
+      .filter(section => section.tasks.length > 0),
+  }
+}
+
+export const filterDocumentToApplicableTasks = (application: Application): ApplicationDocument => {
+  const document = application.document as ApplicationDocument
+
+  const applicableTaskTitles = new Set(
+    getSections().flatMap(section =>
+      section.tasks.filter(task => taskAppliesToApplication(task, application)).map(task => task.title),
+    ),
+  )
+
+  return {
+    sections: document.sections
+      .map(section => {
+        return { ...section, tasks: section.tasks.filter(task => applicableTaskTitles.has(task.title)) }
+      })
+      .filter(section => section.tasks.length > 0),
   }
 }

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -11,7 +11,7 @@ import {
 } from './utils'
 import { fetchErrorsAndUserInput } from '../validation'
 import { DateFormats } from '../dateUtils'
-import { getSections } from '../checkYourAnswersUtils'
+import { getSections, taskAppliesToApplication } from '../checkYourAnswersUtils'
 import config from '../../config'
 import paths from '../../paths/apply'
 import { TaskListService } from '../../services'
@@ -229,12 +229,12 @@ describe('utils', () => {
   })
 
   describe('getSideNavLinksForApplication', () => {
-    it('returns an array with a side nav item for each task', () => {
+    it('returns a side nav item for each task that applies to the application', () => {
       ;(getSections as jest.Mock).mockReturnValue(mockSections)
+      ;(taskAppliesToApplication as jest.Mock).mockImplementation(task => task.id !== 'task2')
 
-      expect(getSideNavLinksForApplication()).toEqual([
+      expect(getSideNavLinksForApplication(applicationFactory.build())).toEqual([
         { text: 'Task 1', href: '#task-1' },
-        { text: 'Task 2', href: '#task-2' },
         { text: 'Task 3', href: '#task-3' },
         { text: 'Task 4', href: '#task-4' },
       ])

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -14,7 +14,7 @@ import type {
   Cas2SubmittedApplication,
   Cas2TimelineEvent,
 } from '@approved-premises/api'
-import { getSections } from '../checkYourAnswersUtils'
+import { getSections, taskAppliesToApplication } from '../checkYourAnswersUtils'
 import { stringToKebabCase, formatCommaToLinebreak } from '../utils'
 import { formatLines, validateReferer } from '../viewUtils'
 import Apply from '../../form-pages/apply'
@@ -81,13 +81,13 @@ export const getSideNavLinksForDocument = (document: ApplicationDocument) => {
   return tasks
 }
 
-export const getSideNavLinksForApplication = () => {
-  const sections = getSections()
-
+export const getSideNavLinksForApplication = (application: Application) => {
   const tasks: Array<SideNavItem> = []
 
-  sections.forEach(section => {
-    section.tasks.forEach(task => tasks.push({ href: `#${stringToKebabCase(task.title)}`, text: task.title }))
+  getSections().forEach(section => {
+    section.tasks
+      .filter(task => taskAppliesToApplication(task, application))
+      .forEach(task => tasks.push({ href: `#${stringToKebabCase(task.title)}`, text: task.title }))
   })
 
   return tasks

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -1,5 +1,5 @@
 import { Cas2Application as Application, Cas2SubmittedApplication, FullPerson } from '@approved-premises/api'
-import { SummaryListItem, FormSection, QuestionAndAnswer } from '@approved-premises/ui'
+import { SummaryListItem, FormSection, QuestionAndAnswer, UiTask } from '@approved-premises/ui'
 import Apply from '../form-pages/apply/index'
 import CheckYourAnswers from '../form-pages/apply/check-your-answers'
 import paths from '../paths/apply'
@@ -7,24 +7,32 @@ import { getQuestions, getQuestion, Questions } from '../form-pages/utils/questi
 import { nameOrPlaceholderCopy } from './utils'
 import { formatLines } from './viewUtils'
 import TaskListPage, { TaskListPageInterface } from '../form-pages/taskListPage'
+import getTaskStatus from '../form-pages/utils/getTaskStatus'
 import { UnknownPageError } from './errors'
 import { DateFormats } from './dateUtils'
+
+export const taskAppliesToApplication = (task: UiTask, application: Application): boolean =>
+  getTaskStatus(task, application) !== 'not_applicable'
 
 export const checkYourAnswersSections = (application: Application) => {
   const sections = getSections()
 
-  const sectionsWithAnswers = sections.map(section => {
-    return {
-      title: section.title,
-      tasks: section.tasks.map(task => {
-        return {
-          id: task.id,
-          title: task.title,
-          rows: getTaskAnswersAsSummaryListItems(task.id, application),
-        }
-      }),
-    }
-  })
+  const sectionsWithAnswers = sections
+    .map(section => {
+      return {
+        title: section.title,
+        tasks: section.tasks
+          .filter(task => taskAppliesToApplication(task, application))
+          .map(task => {
+            return {
+              id: task.id,
+              title: task.title,
+              rows: getTaskAnswersAsSummaryListItems(task.id, application),
+            }
+          }),
+      }
+    })
+    .filter(section => section.tasks.length > 0)
 
   return sectionsWithAnswers
 }

--- a/server/views/applications/pages/check-your-answers/check-your-answers.njk
+++ b/server/views/applications/pages/check-your-answers/check-your-answers.njk
@@ -32,7 +32,7 @@
       <div class="govuk-grid-row">
 
         <div class="govuk-grid-column-one-quarter side-nav">
-          {{ sideNav(getSideNavLinksForApplication()) }}
+          {{ sideNav(getSideNavLinksForApplication(page.application)) }}
         </div>
 
         <div class="govuk-grid-column-three-quarters">


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/FM-895

# Changes in this PR

- Added a filter in document rendering (check-your-answers as well) that will now filter out tasks that are not applicable to the specific cohort. This applies to all cohorts

Edit: Haven't run the E2E tests locally (facing some issues with that today) but they shouldn't break. (won't merge until we are certain though they pass 100%)

## Screenshots of UI changes

<details>
<summary>Before (court-bail on check-your-answers route)</summary>
<img width="614" height="722" alt="Screenshot 2026-07-21 at 10 02 26" src="https://github.com/user-attachments/assets/5117dd0b-f2e6-47d9-86dc-12b8cea9e484" />
</details>

<details>
<summary>After (court-bail on check-your-answers route)</summary>
<img width="610" height="601" alt="Screenshot 2026-07-21 at 10 31 44" src="https://github.com/user-attachments/assets/57262e26-9f9b-44bc-a9cb-b4e1564f60d8" />
</details>

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
