### PR TITLE
Risk tasks to hit the OldOasys path

### DIFF
--- a/integration_tests/tests/apply/health-needs/risk-to-self.cy.ts
+++ b/integration_tests/tests/apply/health-needs/risk-to-self.cy.ts
@@ -163,7 +163,9 @@ context('Risk to self task', () => {
       person,
       data: { ...this.applicationData, 'risk-to-self': undefined },
     })
-    const data = cas2OAsysRiskToSelfDtoFactory.build()
+    const data = cas2OAsysRiskToSelfDtoFactory.build({
+      metadata: { hasApplicableAssessment: true, dateStarted: '2026-01-01', dateCompleted: '2026-01-02' },
+    })
 
     cy.task('stubApplicationGet', { application })
     cy.task('stubApplicationUpdate', { application })
@@ -200,6 +202,36 @@ context('Risk to self task', () => {
 
     // And the risk detail should be populated
     riskPage.shouldShowTextArea('currentAndPreviousRiskDetail', data.analysisSuicideSelfharm)
+  })
+
+  it('shows the no OASys record page then continues to the old OASys question when there is no applicable assessment', function test() {
+    const application = applicationFactory.build({
+      applicationOrigin: 'other',
+      person,
+      data: { ...this.applicationData, 'risk-to-self': undefined },
+    })
+    const data = cas2OAsysRiskToSelfDtoFactory.build({ metadata: { hasApplicableAssessment: false } })
+
+    cy.task('stubApplicationGet', { application })
+    cy.task('stubApplicationUpdate', { application })
+    cy.task('stubGetOasysRiskToSelf', { person, data })
+
+    // Given I am on the tasklist page
+    TaskListPage.visit(application)
+    const taskListPage = Page.verifyOnPage(TaskListPage, application)
+
+    // When I start the risk-to-self task
+    taskListPage.visitTask('Add risk to self information')
+
+    // Then I am on the oasys import page showing no oasys record
+    const oasysImportPage = Page.verifyOnPage(OasysImportPage, application)
+    oasysImportPage.verifyNoOasys()
+
+    // When I click continue
+    oasysImportPage.clickLink('Continue')
+
+    // Then I am on the old-oasys question page
+    Page.verifyOnPage(OldOasysPage, application)
   })
 
   it('The risk to self task is not shown for bail applications', function test() {

--- a/server/form-pages/apply/health-needs/risk-to-self/custom-forms/oasysImport.test.ts
+++ b/server/form-pages/apply/health-needs/risk-to-self/custom-forms/oasysImport.test.ts
@@ -20,6 +20,7 @@ describe('OasysImport', () => {
   const application = applicationFactory.build({ person: personFactory.build({ name: 'Roger Smith' }) })
   const oasys = cas2OAsysRiskToSelfDtoFactory.build({
     metadata: {
+      hasApplicableAssessment: true,
       dateCompleted: DateFormats.dateObjToIsoDateTime(new Date(2023, 7, 29)),
       dateStarted: DateFormats.dateObjToIsoDateTime(new Date(2023, 7, 28)),
     },
@@ -83,7 +84,9 @@ describe('OasysImport', () => {
 
       describe('when there is not a completed date', () => {
         it('does not assign a completed date', async () => {
-          const oasysIncomplete = cas2OAsysRiskToSelfDtoFactory.build({ metadata: { dateCompleted: null } })
+          const oasysIncomplete = cas2OAsysRiskToSelfDtoFactory.build({
+            metadata: { hasApplicableAssessment: true, dateCompleted: null },
+          })
 
           ;(dataServices.personService.getOasysRiskToSelf as jest.Mock).mockResolvedValue(oasysIncomplete)
 
@@ -91,6 +94,18 @@ describe('OasysImport', () => {
 
           expect(page.oasysCompleted).toBe(null)
         })
+      })
+    })
+
+    describe('when there is no applicable assessment to import', () => {
+      it('sets hasOasysRecord to false so the no OASys record page is shown', async () => {
+        ;(dataServices.personService.getOasysRiskToSelf as jest.Mock).mockResolvedValue(null)
+
+        const page = (await OasysImport.initialize({}, application, request, dataServices)) as OasysImport
+
+        expect(page.hasOasysRecord).toBe(false)
+        expect(page.oasysCompleted).toBe(undefined)
+        expect(page.oasysStarted).toBe(undefined)
       })
     })
 

--- a/server/form-pages/apply/health-needs/risk-to-self/custom-forms/oasysImport.ts
+++ b/server/form-pages/apply/health-needs/risk-to-self/custom-forms/oasysImport.ts
@@ -84,7 +84,9 @@ export default class OasysImport implements TaskListPage {
       try {
         oasys = await dataServices.personService.getOasysRiskToSelf(request.user.token, application.person.crn)
 
-        taskDataJson = JSON.stringify(OasysImport.getTaskData(oasys))
+        if (oasys) {
+          taskDataJson = JSON.stringify(OasysImport.getTaskData(oasys))
+        }
       } catch (e) {
         logOasysError(e, application.person.crn)
         oasys = null

--- a/server/form-pages/apply/health-needs/risks-of-serious-harm-to-others/oasysImport.test.ts
+++ b/server/form-pages/apply/health-needs/risks-of-serious-harm-to-others/oasysImport.test.ts
@@ -121,6 +121,21 @@ describe('OasysImport', () => {
       })
     })
 
+    describe('when there is no applicable assessment to import', () => {
+      it('sets hasOasysRecord to false so the no OASys record page is shown', async () => {
+        ;(dataServices.personService.getOasysRosh as jest.Mock).mockResolvedValue(null)
+
+        const page = (await OasysImport.initialize(
+          {},
+          application,
+          { user: { token: 'some-token' } } as never,
+          dataServices,
+        )) as OasysImport
+
+        expect(page.hasOasysRecord).toBe(false)
+      })
+    })
+
     describe('when oasys sections are not returned', () => {
       it('sets hasOasysRecord to false when an error is returned', async () => {
         ;(dataServices.personService.getOasysRosh as jest.Mock).mockRejectedValue(new Error())

--- a/server/form-pages/apply/health-needs/risks-of-serious-harm-to-others/oasysImport.ts
+++ b/server/form-pages/apply/health-needs/risks-of-serious-harm-to-others/oasysImport.ts
@@ -83,8 +83,11 @@ export default class OasysImport implements TaskListPage {
     if (!application.data?.['risks-of-serious-harm-to-others']) {
       try {
         oasys = await dataServices.personService.getOasysRosh(request.user.token, application.person.crn)
-        risks = await dataServices.personService.getRoshRisks(request.user.token, application.person.crn)
-        taskDataJson = JSON.stringify(OasysImport.getTaskData(oasys, risks))
+
+        if (oasys) {
+          risks = await dataServices.personService.getRoshRisks(request.user.token, application.person.crn)
+          taskDataJson = JSON.stringify(OasysImport.getTaskData(oasys, risks))
+        }
       } catch (e) {
         logOasysError(e, application.person.crn)
         oasys = null

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -1,4 +1,9 @@
-import { cas2OAsysRoshRatingsDtoFactory, cas2OAsysRoshSummaryDtoFactory, personFactory } from '../testutils/factories'
+import {
+  cas2OAsysRiskToSelfDtoFactory,
+  cas2OAsysRoshRatingsDtoFactory,
+  cas2OAsysRoshSummaryDtoFactory,
+  personFactory,
+} from '../testutils/factories'
 import PersonService from './personService'
 import { PersonClient } from '../data'
 
@@ -130,6 +135,17 @@ describe('Person Service', () => {
       const result = await service.getRoshRisks(token, 'crn')
 
       expect(result).toEqual({ status: 'not_found' })
+    })
+  })
+
+  describe('getOasysRiskToSelf', () => {
+    it('returns null when there is no applicable assessment', async () => {
+      const riskToSelf = cas2OAsysRiskToSelfDtoFactory.build({ metadata: { hasApplicableAssessment: false } })
+      personClient.oasysRiskToSelf.mockResolvedValue(riskToSelf)
+
+      const result = await service.getOasysRiskToSelf(token, 'crn')
+
+      expect(result).toBeNull()
     })
   })
 })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -26,8 +26,13 @@ export default class PersonService {
 
   async getOasysRiskToSelf(token: string, crn: string): Promise<Cas2OAsysRiskToSelfDto> {
     const personClient = this.personClientFactory(token)
+    const riskToSelf = await personClient.oasysRiskToSelf(crn)
 
-    return personClient.oasysRiskToSelf(crn)
+    if (!riskToSelf?.metadata?.hasApplicableAssessment) {
+      return null
+    }
+
+    return riskToSelf
   }
 
   async getOasysRosh(token: string, crn: string): Promise<OASysRiskOfSeriousHarm> {

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -24,7 +24,7 @@ export default class PersonService {
     return personClient.searchByCrn(crn)
   }
 
-  async getOasysRiskToSelf(token: string, crn: string): Promise<Cas2OAsysRiskToSelfDto> {
+  async getOasysRiskToSelf(token: string, crn: string): Promise<Cas2OAsysRiskToSelfDto | null> {
     const personClient = this.personClientFactory(token)
     const riskToSelf = await personClient.oasysRiskToSelf(crn)
 


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/FM-946

# Changes in this PR
Risk to self and RoSH tasks now show the "No OASys record available" page and let you continue manuallywhen there's no assessment to import instead of wrongly offering an import.

note: you can test this with a CRN that has no OASYS import


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
