### PR TITLE
FM-989-Clear orphaned data when changing answer to "Are you the probation practitioner" question

### DIFF
--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -7,7 +7,9 @@ import { getApplicationSubmissionData, getApplicationUpdateData } from '../utils
 import TaskListPage, { TaskListPageInterface } from '../form-pages/taskListPage'
 import CheckYourAnswers from '../form-pages/apply/check-your-answers/check-your-answers/checkYourAnswers'
 import { ValidationError } from '../utils/errors'
-import deleteOrphanedFollowOnAnswers from '../utils/applications/deleteOrphanedData'
+import deleteOrphanedFollowOnAnswers, {
+  deleteOrphanedAnswersOnCppCheckChange,
+} from '../utils/applications/deleteOrphanedData'
 
 export default class ApplicationService {
   constructor(private readonly applicationClientFactory: RestClientBuilder<ApplicationClient>) {}
@@ -88,6 +90,7 @@ export default class ApplicationService {
       const oldBody = application.data?.[taskName]?.[pageName]
 
       application.data = this.addPageDataToApplicationData(application.data, taskName, pageName, page)
+      application.data = deleteOrphanedAnswersOnCppCheckChange(application.data, taskName, pageName, oldBody, page.body)
       application.data = deleteOrphanedFollowOnAnswers(application)
       application.data = this.deleteCheckYourAnswersIfPageChange(application.data, pageName, oldBody, page.body)
 

--- a/server/utils/applications/deleteOrphanedData.test.ts
+++ b/server/utils/applications/deleteOrphanedData.test.ts
@@ -1,5 +1,5 @@
 import { Cas2Application, Cas2CohortDto } from '@approved-premises/api'
-import deleteOrphanedFollowOnAnswers from './deleteOrphanedData'
+import deleteOrphanedFollowOnAnswers, { deleteOrphanedAnswersOnCppCheckChange } from './deleteOrphanedData'
 import { applicationFactory } from '../../testutils/factories'
 
 describe('deleteOrphanedFollowOnAnswers', () => {
@@ -602,5 +602,35 @@ describe('deleteOrphanedFollowOnAnswers', () => {
       const expected = { ...data, 'personal-information': { 'custody-location': undefined as Record<string, unknown> } }
       expect(deleteOrphanedFollowOnAnswers(applicationFactory.build({ data, cohort: 'isc' }))).toEqual(expected)
     })
+  })
+})
+
+describe('deleteOrphanedAnswersOnCppCheckChange', () => {
+  const referrerDetails = () => ({
+    'referrer-details': {
+      'cpp-check': { isCpp: 'no' },
+      'community-probation-practitioner-details': { name: 'Some CPP' },
+      'job-title': { jobTitle: 'some job title' },
+      'contact-number': { telephone: '12345' },
+      location: { location: 'some location' },
+    },
+  })
+
+  it.each([
+    ['yes', 'no'],
+    ['no', 'yes'],
+  ])('removes the pages that follow cpp-check when the answer changes from %s to %s', (oldAnswer, newAnswer) => {
+    const applicationData = referrerDetails()
+    applicationData['referrer-details']['cpp-check'] = { isCpp: newAnswer }
+
+    expect(
+      deleteOrphanedAnswersOnCppCheckChange(
+        applicationData,
+        'referrer-details',
+        'cpp-check',
+        { isCpp: oldAnswer },
+        { isCpp: newAnswer },
+      ),
+    ).toEqual({ 'referrer-details': { 'cpp-check': { isCpp: newAnswer } } })
   })
 })

--- a/server/utils/applications/deleteOrphanedData.ts
+++ b/server/utils/applications/deleteOrphanedData.ts
@@ -2,6 +2,26 @@ import { Cas2Application } from '@approved-premises/api'
 import { PreviousConvictionsAnswers } from '../../form-pages/apply/offences-and-concerns/previous-unspent-convictions/anyPreviousConvictions'
 import { custodialCohorts } from './cohortLabels'
 
+export const deleteOrphanedAnswersOnCppCheckChange = (
+  applicationData: Cas2Application['data'],
+  taskName: string,
+  pageName: string,
+  oldBody: Record<string, unknown>,
+  newBody: Record<string, unknown>,
+): Cas2Application['data'] => {
+  const cppCheckAnswerHasChanged =
+    taskName === 'referrer-details' && pageName === 'cpp-check' && oldBody && oldBody.isCpp !== newBody.isCpp
+
+  if (cppCheckAnswerHasChanged) {
+    delete applicationData['referrer-details']['community-probation-practitioner-details']
+    delete applicationData['referrer-details']['job-title']
+    delete applicationData['referrer-details']['contact-number']
+    delete applicationData['referrer-details'].location
+  }
+
+  return applicationData
+}
+
 export default function deleteOrphanedFollowOnAnswers(application: Cas2Application): Cas2Application {
   const applicationData = application.data
 


### PR DESCRIPTION

# Context

Jira: https://dsdmoj.atlassian.net/browse/FM-989

# Changes in this PR

Fixed a small bug where the Yes/No path in the Referrer question was getting saved in the document even if the user later switched to the other.

## Screenshots of UI changes

<details>
<summary>Before (Probation Practitioner question: Switched from No to Yes path)</summary>

<img width="444" height="190" alt="Before" src="https://github.com/user-attachments/assets/24538c0c-45bf-4152-a5f9-5619b44f9837" />

</details>

<details>
<summary>After Before (Probation Practitioner question: Switched from No to Yes path)</summary>

<img width="450" height="146" alt="After" src="https://github.com/user-attachments/assets/886c90bc-9c04-423a-8a3f-a87248705892" />

</details>


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
