### PR TITLE
FM-990 - Show the correct cohort on applications

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -9,6 +9,7 @@ import {
 import { SummaryListItem } from '@approved-premises/ui'
 import errorLookups from '../../server/i18n/en/errors.json'
 import { DateFormats } from '../../server/utils/dateUtils'
+import { applicationTypeLabel } from '../../server/utils/applications/cohortLabels'
 import paths from '../../server/paths/apply'
 
 export type PageElement = Cypress.Chainable<JQuery>
@@ -166,10 +167,7 @@ export default abstract class Page {
   hasApplicantDetails(application: SubmittedApplication | Application): void {
     const person = application.person as FullPerson
     cy.get(`[data-cy-check-your-answers-section="applicant-details"]`).within(() => {
-      this.checkTermAndDescription(
-        'Application type',
-        application.applicationOrigin === 'courtBail' ? 'Court Bail' : 'Prison Bail',
-      )
+      this.checkTermAndDescription('Application type', applicationTypeLabel(application))
       this.checkTermAndDescription('Full name', person.name)
       this.checkTermAndDescription(
         'Date of birth',

--- a/server/utils/applications/cohortLabels.test.ts
+++ b/server/utils/applications/cohortLabels.test.ts
@@ -1,0 +1,16 @@
+import { submittedApplicationFactory } from '../../testutils/factories'
+import { applicationTypeLabel } from './cohortLabels'
+
+describe('applicationTypeLabel', () => {
+  it('returns the label for the cohort', () => {
+    const application = submittedApplicationFactory.build({ applicationOrigin: 'other', cohort: 'isc' })
+
+    expect(applicationTypeLabel(application)).toEqual('Intensive supervision courts (ISC)')
+  })
+
+  it('falls back to the application origin when there is no cohort', () => {
+    const application = submittedApplicationFactory.build({ applicationOrigin: 'courtBail' })
+
+    expect(applicationTypeLabel(application)).toEqual('Court Bail')
+  })
+})

--- a/server/utils/applications/cohortLabels.ts
+++ b/server/utils/applications/cohortLabels.ts
@@ -1,4 +1,4 @@
-import { Cas2CohortDto } from '@approved-premises/api'
+import { ApplicationOrigin, Cas2Application, Cas2CohortDto, Cas2SubmittedApplication } from '@approved-premises/api'
 
 export type NonBailCohort = Exclude<Cas2CohortDto, 'hdc' | 'prisonBail' | 'courtBail'>
 
@@ -21,3 +21,12 @@ export const cohortLabels: Record<Cas2CohortDto, string> = {
 export const cohortLabel = (cohort?: Cas2CohortDto): string => (cohort ? (cohortLabels[cohort] ?? cohort) : '')
 
 export const custodialCohorts: Array<Cas2CohortDto> = ['rarr', 'hcrd', 'hefr', 'hdc', 'prisonBail', 'courtBail']
+
+export const bailCohorts: Partial<Record<ApplicationOrigin, Cas2CohortDto>> = {
+  courtBail: 'courtBail',
+  prisonBail: 'prisonBail',
+}
+
+// fallback for pre-cohorts!
+export const applicationTypeLabel = (application: Cas2Application | Cas2SubmittedApplication): string =>
+  cohortLabel(application.cohort) || cohortLabel(bailCohorts[application.applicationOrigin])

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -1,10 +1,11 @@
 import {
-  ApplicationOrigin,
   Cas2CohortDto,
   Cas2Application as Application,
   SubmitCas2Application,
   UpdateCas2Application,
 } from '@approved-premises/api'
+
+import { bailCohorts } from './cohortLabels'
 
 import {
   preferredAreasFromAppData,
@@ -16,20 +17,8 @@ export const getApplicationUpdateData = (application: Application, cohort?: Cas2
   return {
     type: 'CAS2V2',
     data: application.data,
-    cohort: cohort || application.cohort || getBailCohort(application.applicationOrigin),
+    cohort: cohort || application.cohort || bailCohorts[application.applicationOrigin],
   }
-}
-
-function getBailCohort(applicationOrigin: ApplicationOrigin): Cas2CohortDto | undefined {
-  if (applicationOrigin === 'courtBail') {
-    return 'courtBail'
-  }
-
-  if (applicationOrigin === 'prisonBail') {
-    return 'prisonBail'
-  }
-
-  return undefined
 }
 
 export const getApplicationSubmissionData = (application: Application): SubmitCas2Application => {

--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -815,18 +815,6 @@ describe('getPage', () => {
       })
     })
 
-    describe('when there is no cohort and the application origin is not a bail one', () => {
-      it('should omit the application type', () => {
-        const person = personFactory.build({})
-
-        const application = applicationFactory.build({ person, applicationOrigin: 'other', cohort: undefined })
-
-        expect(getApplicantDetails(application)).not.toContainEqual(
-          expect.objectContaining({ key: { text: 'Application type' } }),
-        )
-      })
-    })
-
     describe('when the PNC number is missing', () => {
       it('should return applicant details with "Unable to import" for PNC number', () => {
         const person = personFactory.build({ pncNumber: undefined })

--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -815,6 +815,18 @@ describe('getPage', () => {
       })
     })
 
+    describe('when there is no cohort and the application origin is not a bail one', () => {
+      it('should omit the application type', () => {
+        const person = personFactory.build({})
+
+        const application = applicationFactory.build({ person, applicationOrigin: 'other', cohort: undefined })
+
+        expect(getApplicantDetails(application)).not.toContainEqual(
+          expect.objectContaining({ key: { text: 'Application type' } }),
+        )
+      })
+    })
+
     describe('when the PNC number is missing', () => {
       it('should return applicant details with "Unable to import" for PNC number', () => {
         const person = personFactory.build({ pncNumber: undefined })

--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -715,7 +715,7 @@ describe('getPage', () => {
       it('should return applicant details in the correct format', () => {
         const person = personFactory.build({})
 
-        const application = applicationFactory.build({ person, applicationOrigin: 'courtBail' })
+        const application = applicationFactory.build({ person, applicationOrigin: 'courtBail', cohort: 'courtBail' })
 
         const expected = [
           {
@@ -793,6 +793,25 @@ describe('getPage', () => {
         ]
 
         expect(getApplicantDetails(application)).toEqual(expected)
+      })
+    })
+
+    describe('when the application is for one of the new cohorts', () => {
+      it('should return the cohort as the application type', () => {
+        const person = personFactory.build({})
+
+        const application = applicationFactory.newCohort('isc').build({ person })
+
+        const expected = {
+          key: {
+            text: 'Application type',
+          },
+          value: {
+            html: 'Intensive supervision courts (ISC)',
+          },
+        }
+
+        expect(getApplicantDetails(application)).toContainEqual(expected)
       })
     })
 

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -11,6 +11,7 @@ import getTaskStatus from '../form-pages/utils/getTaskStatus'
 import { UnknownPageError } from './errors'
 import { DateFormats } from './dateUtils'
 import { summaryListItem } from './formUtils'
+import { applicationTypeLabel } from './applications/cohortLabels'
 
 export const taskAppliesToApplication = (task: UiTask, application: Application): boolean =>
   getTaskStatus(task, application) !== 'not_applicable'
@@ -233,11 +234,7 @@ export const getApplicantDetails = (application: Application | Cas2SubmittedAppl
     application.person as FullPerson
 
   return [
-    summaryListItem(
-      'Application type',
-      application.applicationOrigin === 'courtBail' ? 'Court Bail' : 'Prison Bail',
-      'html',
-    ),
+    summaryListItem('Application type', applicationTypeLabel(application), 'html', true),
     summaryListItem('Full name', name, 'html'),
     summaryListItem('Date of birth', DateFormats.isoDateToUIDate(dateOfBirth, { format: 'short' }), 'html'),
     summaryListItem('Nationality', nationality || 'Unknown', 'html'),

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -25,6 +25,7 @@ import {
   getSideNavLinksForApplication,
   getSideNavLinksForDocument,
 } from './applications/utils'
+import { applicationTypeLabel } from './applications/cohortLabels'
 import { applicationStatusRadios, applicationStatusDetailOptions } from './assessUtils'
 import { checkYourAnswersSections, getApplicantDetails } from './checkYourAnswersUtils'
 import { DateFormats } from './dateUtils'
@@ -94,6 +95,7 @@ export default function nunjucksSetup(app: express.Express): void {
 
   njkEnv.addGlobal('checkYourAnswersSections', checkYourAnswersSections)
   njkEnv.addGlobal('getApplicantDetails', getApplicantDetails)
+  njkEnv.addGlobal('applicationTypeLabel', applicationTypeLabel)
 
   njkEnv.addGlobal('getApplicationTimelineEvents', getApplicationTimelineEvents)
   njkEnv.addGlobal('applicationStatusRadios', applicationStatusRadios)

--- a/server/views/partials/submittedApplicationDetails.njk
+++ b/server/views/partials/submittedApplicationDetails.njk
@@ -10,7 +10,10 @@
 
   {{ applicationCurrentStatus(status) }}
 
-  <p>Application type: <strong>{{ "Prison Bail" if application.applicationOrigin == 'prisonBail' else "Court Bail" }}</strong></p>
+  {% set applicationType = applicationTypeLabel(application) %}
+  {% if applicationType %}
+    <p>Application type: <strong>{{ applicationType }}</strong></p>
+  {% endif %}
 
   <p>This application was submitted on <strong>{{ formatDate(application.submittedAt, {format: 'medium'}) }}</strong>.</p>
 


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/FM-990

# Changes in this PR

- Added the new exposed cohort to the ui (assessor and referrer view / check your answers + submitted application)
- some minor tidy up

note: just put a small guard/safe fallback for older pre-cohort applications that didn't had access to cohort before submission!

No screenshots as this is just a new data change. 

How to test:

Create an application (submitted / or in progress) as a new cohort. You should be able to see the new cohort type in the following pages (both as Assessor and Referrer):

   /applications/XXXXX/overview
   /applications/XXXXX
   /applications/XXXXX/tasks/check-your-answers/pages/check-your-answers
   

    



# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
