### PR TITLE
Fix path on start new application button on applications page

### DIFF
--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -108,20 +108,20 @@ describe('applicationsController', () => {
     })
 
     it('renders existing applications', async () => {
+      config.flags.cas2IsrEnabled = false
+
       const requestHandler = applicationsController.index()
 
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith(
-        'applications/index',
-        expect.objectContaining({
-          errors: {},
-          errorSummary: [],
-          applications,
-          pageHeading: 'Applications',
-          showPrisonDashboard: true,
-        }),
-      )
+      expect(response.render).toHaveBeenCalledWith('applications/index', {
+        errors: {},
+        errorSummary: [],
+        applications,
+        pageHeading: 'Applications',
+        showPrisonDashboard: true,
+        newApplicationPath: paths.applications.beforeYouStart({}),
+      })
     })
 
     it('links the start a new application button to the new cohorts flow when the ISR flag is enabled', async () => {

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -92,31 +92,66 @@ describe('applicationsController', () => {
   })
 
   describe('index', () => {
-    const priorConfigFlags = config.flags
+    const priorConfigFlags = { ...config.flags }
 
     afterAll(() => {
       config.flags = priorConfigFlags
     })
 
-    it('renders existing applications', async () => {
+    beforeEach(() => {
       response = createMock<Response>({
         locals: { user: { userRoles: ['CAS2_PRISON_BAIL_REFERRER'] } },
       })
       ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
         return { errors: {}, errorSummary: [], userInput: {} }
       })
+    })
+
+    it('renders existing applications', async () => {
+      const requestHandler = applicationsController.index()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith(
+        'applications/index',
+        expect.objectContaining({
+          errors: {},
+          errorSummary: [],
+          applications,
+          pageHeading: 'Applications',
+          showPrisonDashboard: true,
+        }),
+      )
+    })
+
+    it('links the start a new application button to the new cohorts flow when the ISR flag is enabled', async () => {
+      config.flags.cas2IsrEnabled = true
 
       const requestHandler = applicationsController.index()
 
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('applications/index', {
-        errors: {},
-        errorSummary: [],
-        applications,
-        pageHeading: 'Applications',
-        showPrisonDashboard: true,
-      })
+      expect(response.render).toHaveBeenCalledWith(
+        'applications/index',
+        expect.objectContaining({
+          newApplicationPath: paths.applications.newCohorts.applicationOrigin({}),
+        }),
+      )
+    })
+
+    it('links the start a new application button to the bail flow when the ISR flag is disabled', async () => {
+      config.flags.cas2IsrEnabled = false
+
+      const requestHandler = applicationsController.index()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith(
+        'applications/index',
+        expect.objectContaining({
+          newApplicationPath: paths.applications.beforeYouStart({}),
+        }),
+      )
     })
   })
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -19,6 +19,7 @@ import { buildDocument, filterDocumentToApplicableTasks } from '../../utils/appl
 import { hasRole } from '../../utils/userUtils'
 import TaskListService from '../../services/taskListService'
 import { getApplicationSummaryData } from '../../utils/getApplicationSummaryData'
+import config from '../../config'
 
 const dashboardPath = '/'
 
@@ -38,6 +39,10 @@ export default class ApplicationsController {
 
       const showPrisonDashboard = hasRole(res.locals.user.userRoles, 'CAS2_PRISON_BAIL_REFERRER')
 
+      const newApplicationPath = config.flags.cas2IsrEnabled
+        ? paths.applications.newCohorts.applicationOrigin({})
+        : paths.applications.beforeYouStart({})
+
       return res.render('applications/index', {
         errors,
         errorSummary,
@@ -45,6 +50,7 @@ export default class ApplicationsController {
         applications,
         pageHeading: 'Applications',
         showPrisonDashboard,
+        newApplicationPath,
       })
     }
   }

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -120,7 +120,7 @@
 
       {{ softDeleteGuidance() }}
 
-      <a class="govuk-button" href="{{ paths.applications.beforeYouStart() }}">Start a new application</a>
+      <a class="govuk-button" href="{{ newApplicationPath }}">Start a new application</a>
     </div>
   </div>
 


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/FM-1165

Currently the green "Start new application" button on the /applications page sends users to the old bail only path. 
This is wrong, it needs to send them to the new path which is /new-cohorts/applications/application-type

# Changes in this PR

Changed the url and added it behind the flag as well (that is enabled anyway currently)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.
