### PR TITLE
Change 'Referral from Approved Premises' to 'Moved on from Approved Premises'

### DIFF
--- a/integration_tests/pages/homePage.ts
+++ b/integration_tests/pages/homePage.ts
@@ -60,7 +60,7 @@ export default class HomePage extends Page {
         cy.get('li').contains('Homeless at end of fixed-term recall').should('exist')
         cy.get('li').contains('Intensive supervision courts (ISC)').should('exist')
         cy.get('li').contains('Risk Assessed Recall Review (RARR)').should('exist')
-        cy.get('li').contains('Referral from Approved Premises').should('exist')
+        cy.get('li').contains('Moved on from Approved Premises').should('exist')
       })
   }
 

--- a/server/utils/applications/cohortLabels.ts
+++ b/server/utils/applications/cohortLabels.ts
@@ -8,7 +8,7 @@ export const newCohortLabels: Record<NonBailCohort, string> = {
   hefr: 'Homeless at end of fixed-term recall',
   isc: 'Intensive supervision courts (ISC)',
   rarr: 'Risk Assessed Recall Review (RARR)',
-  from_ap: 'Referral from Approved Premises',
+  from_ap: 'Moved on from Approved Premises',
 }
 
 export const cohortLabels: Record<Cas2CohortDto, string> = {

--- a/server/views/dashboard/index.njk
+++ b/server/views/dashboard/index.njk
@@ -45,7 +45,7 @@
         <li>Homeless at end of fixed-term recall</li>
         <li>Intensive supervision courts (ISC)</li>
         <li>Risk Assessed Recall Review (RARR)</li>
-        <li>Referral from Approved Premises</li>
+        <li>Moved on from Approved Premises</li>
       </ul>
     </div>
 


### PR DESCRIPTION
# Context

Changes the name of one of the cohorts
Ticket: [FM-1167](https://dsdmoj.atlassian.net/browse/FM-1167)

If E2E tests fail locally then set `CAS2_ISR_ENABLED=true` and rerun `./script/generate-dotenv-files.sh`

# Changes in this PR

## Screenshots of UI changes

### Before
<img width="848" height="550" alt="image" src="https://github.com/user-attachments/assets/08040816-6eb6-4e03-b7c8-52c24a3d7b74" />
<img width="1114" height="902" alt="image" src="https://github.com/user-attachments/assets/f3ad5886-02f0-40ef-87df-cff76fc58e82" />
<img width="1778" height="962" alt="image" src="https://github.com/user-attachments/assets/14677c69-2781-44f6-9268-2f5a24ea1967" />

### After
<img width="908" height="606" alt="image" src="https://github.com/user-attachments/assets/559c1c6c-d7d2-431c-bec5-2bca27ee26e8" />
<img width="1291" height="1028" alt="image" src="https://github.com/user-attachments/assets/4874e58d-cab5-446c-a6de-b4a809f069dc" />
<img width="1980" height="1077" alt="image" src="https://github.com/user-attachments/assets/5514df57-dd74-49a9-a909-961bf2704766" />

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Are any changes required to the e2e tests?
- [ ] If you've added a new route, have you added a new
  `auditEvent`? (see `server/routes/apply.ts` for examples)
- [ ] Are there environment variables or other infrastructure configuration which needs to be included in this release?
- [ ] Are there any data migrations required. Automatic or manual?
- [ ] Does this rely on changes being deployed to the CAS API?

## Post merge

Once we've merged it will be auto-deployed to the dev environment.


[FM-1167]: https://dsdmoj.atlassian.net/browse/FM-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ